### PR TITLE
Allarchives

### DIFF
--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -73,6 +73,12 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     private ActionMode.Callback mActionModeCallback;
     private ConfigDirectory mSelectedGroup;
 
+    /**
+     * This switch controls whether all archive versions are displayed or just the "Live" ones.
+     */
+    private boolean mShowAllArchiveVersion = true;
+
+
     public ArchivedGroupsFragment() {
     }
 
@@ -247,19 +253,19 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
         super.onStart();
 
 
-     // This code trims all backups from the folder list
-        ArrayList<ConfigDirectory> configFolders = mConfigManager.getDirectories();
-        for (ConfigDirectory temp : configFolders) {
-            if (! temp.isBackup) {
-                mArchivedList.add(temp);
+        //TODO: This is currently a hardcoded boolean. But it is coded this way to preserve both
+        //methods, and potentially it will be switchable in the future
+        if (mShowAllArchiveVersion) {
+            mArchivedList.addAll(mConfigManager.getDirectories());
+        } else {
+            // This code trims all backups from the folder list
+            ArrayList<ConfigDirectory> configFolders = mConfigManager.getDirectories();
+            for (ConfigDirectory temp : configFolders) {
+                if (!temp.isBackup) {
+                    mArchivedList.add(temp);
+                }
             }
         }
-
-
-     // If you want all backups - with multiple versions of a single archive, the block above can be replaced by the line below.
-  //      mArchivedList.addAll(mConfigManager.getDirectories());
-
-
 
 
         mArchivedGroupsAdapter.notifyDataSetChanged();

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -73,6 +73,9 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     private ActionMode.Callback mActionModeCallback;
     private ConfigDirectory mSelectedGroup;
 
+
+
+    //TODO: either expose this switch or remove it.
     /**
      * This switch controls whether all archive versions are displayed or just the "Live" ones.
      */

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
@@ -308,7 +308,8 @@ public final class ConfigManager {
         configChanges.put("maintenance-mode", true);
         configChanges.put("listen", inetAddress + ":" + babblingPort);
         configChanges.put("advertise", inetAddress + ":" + babblingPort);
-
+        configChanges.put("datadir", mTomlDir);
+        configChanges.put("db",  mTomlDir + File.separator+ DB_SUBDIR);
         amendTomlSettings(configChanges);
 
         return mTomlDir;
@@ -614,7 +615,7 @@ public final class ConfigManager {
     public String getUniqueId() {
         UUID uuid = UUID.randomUUID();
         return uuid.toString().replaceAll("-", "");
-      //   return uuid.toString().replaceAll("[^A]", "A");
+        // return uuid.toString().replaceAll("[^A]", "A");
     }
 
     /**

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
@@ -308,8 +308,14 @@ public final class ConfigManager {
         configChanges.put("maintenance-mode", true);
         configChanges.put("listen", inetAddress + ":" + babblingPort);
         configChanges.put("advertise", inetAddress + ":" + babblingPort);
+
+
+        //TODO: possibly move these amendments into the backup config processing to avoid having to
+        //      set them here
         configChanges.put("datadir", mTomlDir);
         configChanges.put("db",  mTomlDir + File.separator+ DB_SUBDIR);
+
+
         amendTomlSettings(configChanges);
 
         return mTomlDir;


### PR DESCRIPTION
Changes to show all versions in the archive view, including a fix to the datadir parameter to make old versions work in archive mode

```java
public class ArchivedGroupsFragment ...

... 

    //TODO: either expose this switch or remove it.
    /**
     * This switch controls whether all archive versions are displayed or just the "Live" ones.
     */
    private boolean mShowAllArchiveVersion = true;
```

There is a boolean switch that is hardcoded that controls whether to show all of the versions of a group, or just one,  in the archive tab. It is done this way to preserve the code for both options for the time being. 
