### PR TITLE
Ensure TabFragment is shown after returning from Group

### DIFF
--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -46,6 +46,7 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
 
     private FragmentManager mFragmentManager;
     public static final String PREFERENCE_FILE_KEY = "babbleandroid";
+    private Boolean mFromGroup = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -75,17 +76,19 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
         fragmentTransaction.commit();
     }
 
-    private void replaceFragment(Fragment fragment) {
+    private void replaceFragment(Fragment fragment, Boolean addToBackStack) {
         FragmentTransaction fragmentTransaction = mFragmentManager.beginTransaction();
         fragmentTransaction.replace(R.id.constraint_layout, fragment);
-        fragmentTransaction.addToBackStack(null);
+        if (addToBackStack) {
+            fragmentTransaction.addToBackStack(null);
+        }
         fragmentTransaction.commit();
     }
 
     // called when the user presses the new group (plus) button
     public void newGroup(View view) {
         NewGroupFragment mNewGroupFragment = NewGroupFragment.newInstance();
-        replaceFragment(mNewGroupFragment);
+        replaceFragment(mNewGroupFragment, true);
     }
 
     @Override
@@ -102,16 +105,35 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
     @Override
     public void onServiceSelected(ResolvedGroup resolvedGroup) {
         JoinGroupFragment mJoinGroupMdnsFragment = JoinGroupFragment.newInstance(resolvedGroup);
-        replaceFragment(mJoinGroupMdnsFragment);
+        replaceFragment(mJoinGroupMdnsFragment, true);
+    }
+
+    @Override
+    public void baseOnJoined(String moniker) {
+        onJoined(moniker);
+        mFromGroup = true;
+    }
+
+    @Override
+    public void baseOnStartedNew(String moniker) {
+        onStartedNew(moniker);
+        mFromGroup = true;
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (mFromGroup) {
+            mFragmentManager.popBackStack();
+            mFromGroup = false;
+        }
     }
 
     @Override
     public abstract BabbleService getBabbleService();
 
-    @Override
     public abstract void onJoined(String moniker);
 
-    @Override
     public abstract void onStartedNew(String moniker);
 
     @Override

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/JoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/JoinGroupFragment.java
@@ -221,7 +221,7 @@ public class JoinGroupFragment extends Fragment implements ResponseListener {
         }
 
         mLoadingDialog.dismiss();
-        mListener.onJoined(mMoniker);
+        mListener.baseOnJoined(mMoniker);
     }
 
     @Override

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
@@ -182,7 +182,7 @@ public class NewGroupFragment extends Fragment {
 
         try {
             babbleService.start(configDirectory, groupDescriptor);
-            mListener.onStartedNew(moniker);
+            mListener.baseOnStartedNew(moniker);
         } catch (Exception ex) {
             //TODO: Review this. The duplicate dialog function feels overkill.
             displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage() );

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/OnFragmentInteractionListener.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/OnFragmentInteractionListener.java
@@ -47,7 +47,7 @@ public interface OnFragmentInteractionListener {
      *
      * @param moniker the moniker chosen by the user
      */
-    void onJoined(String moniker);
+    void baseOnJoined(String moniker);
 
     /**
      * This method will be called when the {@link BabbleService} has successfully started a new
@@ -55,7 +55,7 @@ public interface OnFragmentInteractionListener {
      *
      * @param moniker the moniker chosen by the user
      */
-    void onStartedNew(String moniker);
+    void baseOnStartedNew(String moniker);
 
     /**
      * This method will be called when the {@link BabbleService} has loaded an archive group


### PR DESCRIPTION
Previously when back was pressed from the Sample app's ChatActivity the
BaseConfigActivity would pick up where it left off - either displaying the
JoinGroupFragment or the NewGroupFragment. This change means it will now
display the TabFragment. This is handled in the onStart method, which means
care needs to be taken to ensure this Fragment replacement only occurs when
starting after onJoin or onNew and not after a config change.