### PR TITLE
Ui cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## UNRELEASED
+
+SECURITY:
+
+FEATURES:
+
+IMPROVEMENTS:
+
+- group UID is now displayed in the live groups list
+- added group UID to archive view and changed text colour of backup archives to light gray
+- display a message if archive is empty in Sample app ChatActivity
+- display message if no archives found
+- add swipe refresh on mDNS service search
+
+BUG FIXES:
+
+- Fix bug when refreshing after mDNS start failure
+
 ## v0.3.1 (February 10, 2020)
 
 SECURITY:

--- a/RELEASE-PROCESS.md
+++ b/RELEASE-PROCESS.md
@@ -30,6 +30,6 @@ file. NOTE: there are THREE parameters here, all of which must be incremented.
 
 10. Create a git tag.
 
-11. Push the develop and master branches to github.
+11. Push the develop and master branches and tags to github.
 
 12. Upload to bintray ```gradlew bintrayUpload```.

--- a/babble/build.gradle
+++ b/babble/build.gradle
@@ -33,13 +33,13 @@ apply plugin: 'com.jfrog.bintray'
 //##################################################################################################
 // babble core configuration
 
-def babbleCoreVersion = "0.6.2"
-def repository = "https://github.com/mosaicnetworks/babble/releases/download"
-def protocol = "https"
+//def babbleCoreVersion = "0.6.2"
+//def repository = "https://github.com/mosaicnetworks/babble/releases/download"
+//def protocol = "https"
 
-// def babbleCoreVersion = "a3160dc72421ce9f7c71c9bc72d9f2092d953054"
-// def repository = System.properties['user.home'] + "/go/src/github.com/mosaicnetworks/babble/build/distmobile"
-// def protocol = "file"
+def babbleCoreVersion = "767fcb678bbeb9506ac54160ea1cb85e037c5366"
+def repository = System.properties['user.home'] + "/go/src/github.com/mosaicnetworks/babble/build/distmobile"
+def protocol = "file"
 
 //##################################################################################################
 
@@ -177,6 +177,7 @@ dependencies {
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
 }
 
 artifacts {

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -359,11 +359,13 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
 
     // stores and recycles views as they are scrolled off screen
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
-        TextView genericTextView;
+        TextView groupNameTextView;
+        TextView groupUidTextView;
 
         ViewHolder(View itemView) {
             super(itemView);
-            genericTextView = itemView.findViewById(R.id.serviceName);
+            groupNameTextView = itemView.findViewById(R.id.serviceName);
+            groupUidTextView = itemView.findViewById(R.id.groupUid);
             itemView.setOnClickListener(this);
             itemView.setOnLongClickListener(this);
         }
@@ -384,13 +386,14 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
     private List<ConfigDirectory> mData;
     private LayoutInflater mInflater;
     private ItemClickListener mClickListener;
+    private Context mContext;
 
     public ArchivedGroupsAdapter(Context context, List<ConfigDirectory> data) {
         this.mInflater = LayoutInflater.from(context);
         this.mData = data;
+        mContext = context;
     }
 
-    // inflates the row layout from xml when needed
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -398,15 +401,29 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
         return new ViewHolder(view);
     }
 
-    // binds the data to the TextView in each row
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        String serviceName = mData.get(position).description;
+        ConfigDirectory configDirectory = mData.get(position);
+        String serviceName = configDirectory.description;
+        String groupUid = configDirectory.uniqueId;
 
-        holder.genericTextView.setText(serviceName);
+        holder.groupNameTextView.setText(serviceName);
+        holder.groupUidTextView.setText(groupUid);
+
+        int colourGroupName;
+        int colourGroupUid;
+        if (configDirectory.isBackup) {
+            colourGroupName = R.color.colorArchivedGroup;
+            colourGroupUid = R.color.colorArchivedGroup;
+        } else {
+            colourGroupName = android.R.color.primary_text_light;
+            colourGroupUid = android.R.color.secondary_text_light;
+        }
+
+        holder.groupNameTextView.setTextColor(mContext.getResources().getColor(colourGroupName));
+        holder.groupUidTextView.setTextColor(mContext.getResources().getColor(colourGroupUid));
     }
 
-    // total number of rows
     @Override
     public int getItemCount() {
         if (mData == null) {
@@ -416,12 +433,10 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
         }
     }
 
-    // convenience method for getting data at click position
     public ConfigDirectory getItem(int id) {
         return mData.get(id);
     }
 
-    // allows clicks events to be caught
     public void setClickListener(ItemClickListener itemClickListener) {
         this.mClickListener = itemClickListener;
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -28,13 +28,15 @@ import android.content.Context;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import android.util.Log;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -42,17 +44,16 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.FileSystemNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import io.mosaicnetworks.babble.R;
-import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.node.ConfigDirectory;
 import io.mosaicnetworks.babble.node.ConfigManager;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
@@ -69,10 +70,15 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     private ArchivedGroupsAdapter mArchivedGroupsAdapter;
     private List<ConfigDirectory> mArchivedList = new ArrayList<>();
     private ConfigManager mConfigManager;
-    private View mPreviousLongClickView;
     private ActionMode mActionMode;
     private ActionMode.Callback mActionModeCallback;
-    private ConfigDirectory mSelectedGroup;
+    private List<ConfigDirectory> mSelectedGroupsConfigs = new ArrayList<>();
+    private List<View> mSelectedGroupsViews = new ArrayList<>();
+    private ArchivedGroupsViewModel mViewModel;
+    private RecyclerView mRvArchivedGroups;
+    private LinearLayout mLinearLayoutArchiveLoading;
+    private Boolean mSelected;
+
 
     //TODO: either expose this switch or remove it.
     /**
@@ -95,7 +101,7 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState)  {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         try {
             mConfigManager = ConfigManager.getInstance(Objects.requireNonNull(getContext()).getApplicationContext());
@@ -108,76 +114,115 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
                                                 // The app will terminate. But babble is unstartable from here.
         }
         initActionModeCallback();
+
+        mViewModel = ViewModelProviders.of(this, new ArchivedGroupsViewModelFactory(mListener.getBabbleService())).get(ArchivedGroupsViewModel.class);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_archived_groups, container, false);
-        RecyclerView mRvArchivedGroups = view.findViewById(R.id.rv_archived_groups);
-        mRvArchivedGroups.setLayoutManager(new LinearLayoutManager(getContext()));
         mArchivedGroupsAdapter = new ArchivedGroupsAdapter(getContext(), mArchivedList);
         mArchivedGroupsAdapter.setClickListener(this);
+        mRvArchivedGroups = view.findViewById(R.id.rv_archived_groups);
+        mRvArchivedGroups.setLayoutManager(new LinearLayoutManager(getContext()));
         mRvArchivedGroups.setAdapter(mArchivedGroupsAdapter);
+
+        mLinearLayoutArchiveLoading = view.findViewById(R.id.linearLayout_archive_loading);
+
+        final Observer<ArchivedGroupsViewModel.State> viewModelState = new Observer<ArchivedGroupsViewModel.State>() {
+            @Override
+            public void onChanged(@Nullable final ArchivedGroupsViewModel.State newState) {
+                onViewModelStateChanged(newState);
+            }
+        };
+
+        mViewModel.getState().observe(this, viewModelState);
+
         return view;
     }
 
+    private void onViewModelStateChanged(ArchivedGroupsViewModel.State state) {
+
+        switch (state) {
+            case LIST:
+                mRvArchivedGroups.setVisibility(View.VISIBLE);
+                mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                break;
+            case LOADING:
+                mRvArchivedGroups.setVisibility(View.GONE);
+                mLinearLayoutArchiveLoading.setVisibility(View.VISIBLE);
+                break;
+            case LOADED:
+                //If it loads when we're on a different tab then abort. This does mean it's possible
+                //for a configuration change to cause an abort
+                if (isResumed()) {
+                    mListener.onArchiveLoaded("made up moniker"); //TODO: fix moniker
+                } else {
+                    mListener.getBabbleService().leave(null);
+                    mViewModel.getState().setValue(ArchivedGroupsViewModel.State.LIST);
+                }
+                break;
+            case FAILED:
+                displayOkAlertDialog(R.string.archive_load_fail_title, R.string.archive_load_fail_message);
+                mViewModel.getState().setValue(ArchivedGroupsViewModel.State.LIST);
+        }
+    }
+
     @Override
-    public void onItemShortClick(ConfigDirectory configDirectory) {
+    public void onItemShortClick(View view, ConfigDirectory configDirectory) {
 
+        if (mSelectedGroupsViews.isEmpty()) {
 
-        Log.i("onItemClick", configDirectory.directoryName);
+            try {
+                mConfigManager.setGroupToArchive(configDirectory, Utils.getIPAddr(Objects.requireNonNull(getContext())), ConfigManager.DEFAULT_BABBLING_PORT);
 
+            } catch (IOException e) {
+                displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot load configuration: " + e.getMessage());
+                return;
+            } catch (Exception e) {
+                displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot load configuration: " + e.getClass().getCanonicalName() + ": " + e.getMessage());
+                throw e;
+            }
 
-        try {
-            mConfigManager.setGroupToArchive(configDirectory, Utils.getIPAddr(Objects.requireNonNull(getContext())), ConfigManager.DEFAULT_BABBLING_PORT);
+            try {
+                String configDir = mConfigManager.getTomlDir();
+                mViewModel.loadArchive(configDir, new GroupDescriptor("Archived Group")); //TODO: need to get a proper group descriptor
 
-        } catch (IOException e)
-        {
-            displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot load configuration: "+  e.getMessage() );
-            return;
-        } catch (Exception e)
-        {
-            displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot load configuration: "+ e.getClass().getCanonicalName()+": "+ e.getMessage() );
-            throw e;
+            } catch (IllegalArgumentException ex) {
+                displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: Illegal Argument: " + ex.getClass().getCanonicalName() + ": " + ex.getMessage());
+            } catch (Exception ex) {
+                //TODO: Some sensible error handling here.
+                //Errors on starting the babble service were untrapped and killing the app
+                displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: " + ex.getClass().getCanonicalName() + ": " + ex.getMessage());
+                throw ex;
+                //          Toast.makeText(getContext(), "Cannot start babble: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage(), Toast.LENGTH_LONG).show();
+            }
+
+        } else {
+            mSelectedGroupsConfigs.add(configDirectory);
+            mSelectedGroupsViews.add(view);
+            view.setSelected(true);
+
+            //TODO: need to un select if clicked again?
         }
-
-
-
-        try {
-
-            String configDir = mConfigManager.getTomlDir();
-            Log.d("MY-TAG", "Config directory name: " + configDir);
-            BabbleService<?> babbleService = mListener.getBabbleService();
-            babbleService.start(configDir, new GroupDescriptor("Archived Group")); //TODO: need to get a proper group descriptor + need to NOT advertise mDNS
-            mListener.onArchiveLoaded(mConfigManager.getMoniker());
-
-        } catch (IllegalArgumentException ex) {
-            displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: Illegal Argument: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage() );
-        } catch (Exception ex) {
-            //TODO: Some sensible error handling here.
-            //Errors on starting the babble service were untrapped and killing the app
-            displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage() );
-            throw ex;
-  //          Toast.makeText(getContext(), "Cannot start babble: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage(), Toast.LENGTH_LONG).show();
-        }
-
-
     }
 
     /** Called when the user long clicks a group in the archive list*/
     public void onItemLongClick(View view, ConfigDirectory configDirectory) {
 
-        // un-highlight previously selected view
-        if (mPreviousLongClickView != null) {
-            mPreviousLongClickView.setSelected(false);
+        // un-highlight previously selected views
+        for (View viewS:mSelectedGroupsViews) {
+            viewS.setSelected(false);
         }
-
         // highlight selected
         view.setSelected(true);
-        mPreviousLongClickView = view;
 
-        mSelectedGroup = configDirectory;
+        mSelectedGroupsConfigs = new ArrayList<>();
+        mSelectedGroupsConfigs.add(configDirectory);
+
+        mSelectedGroupsViews = new ArrayList<>();
+        mSelectedGroupsViews.add(view);
 
         if (mActionMode == null) {
             // Start the CAB
@@ -210,10 +255,15 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
                 int itemId = item.getItemId();
 
                 if (itemId == R.id.delete_contact) {
-                    mConfigManager.deleteDirectoryAndBackups(mSelectedGroup.directoryName, false);
-                    mArchivedList.remove(mSelectedGroup);
+
+                    for (ConfigDirectory configDirectory: mSelectedGroupsConfigs) {
+                        mConfigManager.deleteDirectoryAndBackups(configDirectory.directoryName, false);
+                        mArchivedList.remove(configDirectory);
+                    }
+
                     mArchivedGroupsAdapter.notifyDataSetChanged();
                     mode.finish();
+
                     return true;
                 }
 
@@ -223,10 +273,13 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
             // Called when the user exits the action mode
             @Override
             public void onDestroyActionMode(ActionMode mode) {
-                // un-highlight previously selected view
-                if (mPreviousLongClickView != null) {
-                    mPreviousLongClickView.setSelected(false);
+                // un-highlight previously selected views
+                for (View lView:mSelectedGroupsViews) {
+                    lView.setSelected(false);
                 }
+
+                mSelectedGroupsViews.clear();
+                mSelectedGroupsConfigs.clear();
 
                 mActionMode = null;
             }
@@ -254,7 +307,6 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     public void onStart() {
         super.onStart();
 
-
         //TODO: This is currently a hardcoded boolean. But it is coded this way to preserve both
         //methods, and potentially it will be switchable in the future
         if (mShowAllArchiveVersion) {
@@ -269,7 +321,6 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
             }
         }
 
-
         mArchivedGroupsAdapter.notifyDataSetChanged();
     }
 
@@ -278,8 +329,11 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
         super.onStop();
         mArchivedList.clear();
         mArchivedGroupsAdapter.notifyDataSetChanged();
-    }
 
+        if (mViewModel.getState().getValue() == ArchivedGroupsViewModel.State.LOADED) {
+            mViewModel.getState().setValue(ArchivedGroupsViewModel.State.LIST);
+        }
+    }
 
     //TODO: Review if we need these functions in Archive, Join and New fragments.
     private void displayOkAlertDialog(@StringRes int titleId, @StringRes int messageId) {
@@ -290,8 +344,6 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
                 .create();
         alertDialog.show();
     }
-
-
 
     private void displayOkAlertDialogText(@StringRes int titleId, String message) {
         AlertDialog alertDialog = new AlertDialog.Builder(Objects.requireNonNull(getContext()))
@@ -318,7 +370,7 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
 
         @Override
         public void onClick(View view) {
-            if (mClickListener != null) mClickListener.onItemShortClick(mData.get(getAdapterPosition()));
+            if (mClickListener != null) mClickListener.onItemShortClick(view, mData.get(getAdapterPosition()));
         }
 
         @Override
@@ -377,7 +429,7 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
     // parent activity will implement this method to respond to click events
     public interface ItemClickListener {
 
-        void onItemShortClick(ConfigDirectory configDirectory);
+        void onItemShortClick(View view, ConfigDirectory configDirectory);
 
         void onItemLongClick(View view, ConfigDirectory configDirectory);
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -77,6 +77,7 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     private ArchivedGroupsViewModel mViewModel;
     private RecyclerView mRvArchivedGroups;
     private LinearLayout mLinearLayoutArchiveLoading;
+    private LinearLayout mLinearLayoutNoArchives;
     private Boolean mSelected;
 
 
@@ -129,6 +130,7 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
         mRvArchivedGroups.setAdapter(mArchivedGroupsAdapter);
 
         mLinearLayoutArchiveLoading = view.findViewById(R.id.linearLayout_archive_loading);
+        mLinearLayoutNoArchives = view.findViewById(R.id.linearLayout_no_archives);
 
         final Observer<ArchivedGroupsViewModel.State> viewModelState = new Observer<ArchivedGroupsViewModel.State>() {
             @Override
@@ -146,8 +148,15 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
 
         switch (state) {
             case LIST:
-                mRvArchivedGroups.setVisibility(View.VISIBLE);
-                mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                if (mArchivedList.isEmpty()) {
+                    mLinearLayoutNoArchives.setVisibility(View.VISIBLE);
+                    mRvArchivedGroups.setVisibility(View.GONE);
+                    mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                } else {
+                    mLinearLayoutNoArchives.setVisibility(View.GONE);
+                    mRvArchivedGroups.setVisibility(View.VISIBLE);
+                    mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                }
                 break;
             case LOADING:
                 mRvArchivedGroups.setVisibility(View.GONE);
@@ -259,6 +268,12 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
                     for (ConfigDirectory configDirectory: mSelectedGroupsConfigs) {
                         mConfigManager.deleteDirectoryAndBackups(configDirectory.directoryName, false);
                         mArchivedList.remove(configDirectory);
+                    }
+
+                    if (mArchivedList.isEmpty()) {
+                        mLinearLayoutNoArchives.setVisibility(View.VISIBLE);
+                        mRvArchivedGroups.setVisibility(View.GONE);
+                        mLinearLayoutArchiveLoading.setVisibility(View.GONE);
                     }
 
                     mArchivedGroupsAdapter.notifyDataSetChanged();

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModel.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModel.java
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.configure;
+
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import io.mosaicnetworks.babble.node.BabbleService;
+import io.mosaicnetworks.babble.node.GroupDescriptor;
+
+public class ArchivedGroupsViewModel extends ViewModel {
+
+    //TODO: are these the right states
+    //TODO: extra state leaving?
+    public enum State {
+        LIST,
+        LOADING,
+        LOADED,
+        FAILED,
+    }
+
+    private MutableLiveData<State> mState;
+    private BabbleService mBabbleService;
+    private String mConfigDirectory;
+    private GroupDescriptor mGroupDescriptor;
+
+    public ArchivedGroupsViewModel(BabbleService babbleService) {
+        super();
+        mBabbleService = babbleService;
+
+        mState = new MutableLiveData<>();
+        mState.setValue(State.LIST);
+    }
+
+    public void loadArchive(String configDirectory, GroupDescriptor groupDescriptor) {
+        mState.setValue(State.LOADING);
+
+        mBabbleService.startArchive(configDirectory, groupDescriptor, new BabbleService.StartArchiveListener() {
+            @Override
+            public void onInitialised() {
+                mState.postValue(State.LOADED);
+            }
+
+            @Override
+            public void onFailed() {
+                mState.postValue(State.FAILED);
+            }
+        });
+    }
+
+    public MutableLiveData<State> getState() {
+        return mState;
+    }
+
+}
+

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModelFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModelFactory.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.configure;
+
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import io.mosaicnetworks.babble.node.BabbleService;
+
+public class ArchivedGroupsViewModelFactory implements ViewModelProvider.Factory {
+
+    private BabbleService mBabbleService;
+
+    public ArchivedGroupsViewModelFactory(BabbleService babbleService) {
+        mBabbleService = babbleService;
+    }
+
+    //TODO: fix unchecked cast
+    @Override
+    public <T extends ViewModel> T create(Class<T> modelClass) {
+        return (T) new ArchivedGroupsViewModel(mBabbleService);
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -24,7 +24,6 @@
 
 package io.mosaicnetworks.babble.configure;
 
-import android.net.nsd.NsdServiceInfo;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -54,9 +53,14 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
         setContentView(R.layout.activity_base_config);
 
         mFragmentManager = getSupportFragmentManager();
-        TabsFragment mHomeFragment = TabsFragment.newInstance();
 
-        addFragment(mHomeFragment);
+        //"When a config change occurs the old Fragment adds itself to the new Activity when it's
+        //recreated". - https://stackoverflow.com/questions/8474104/android-fragment-lifecycle-over-orientation-changes
+        //Check if fragment is already added to avoid attaching multiple instances of the fragment
+        TabsFragment fragment = (TabsFragment) mFragmentManager.findFragmentById(R.id.constraint_layout);
+        if (fragment == null) {
+            addFragment(TabsFragment.newInstance());
+        }
     }
 
     private void addFragment(Fragment fragment) {
@@ -82,6 +86,17 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
     public void newGroup(View view) {
         NewGroupFragment mNewGroupFragment = NewGroupFragment.newInstance();
         replaceFragment(mNewGroupFragment);
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+
+        // If an archive is loading and the user presses the back button. This activity will be
+        // destroyed, if in the meantime the service transitions into the "ARCHIVE" state, when the
+        // app is restarted the service won't be in the "STOPPED" or "ARCHIVE-INIT" state which this
+        // activity expects
+        getBabbleService().stop();
     }
 
     @Override

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/MdnsDiscoveryFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/MdnsDiscoveryFragment.java
@@ -48,7 +48,7 @@ public class MdnsDiscoveryFragment extends Fragment {
 
     private OnFragmentInteractionListener mListener;
     private ServicesListView mServiceListView;
-    private LinearLayout mLinearLayoutServiceSearch;
+    public SwipeRefreshLayout mSwipeRefreshServiceSearch;
     private SwipeRefreshLayout mSwipeRefreshDiscoveryFailed;
     private SwipeRefreshLayout mSwipeRefreshServicesDisplaying;
 
@@ -77,7 +77,7 @@ public class MdnsDiscoveryFragment extends Fragment {
         final View view = inflater.inflate(R.layout.fragment_mdns_discovery, container, false);
 
         mServiceListView = view.findViewById(R.id.servicesListView);
-        mLinearLayoutServiceSearch = view.findViewById(R.id.linearLayout_service_search);
+        mSwipeRefreshServiceSearch = view.findViewById(R.id.swipeRefresh_service_search);
         mSwipeRefreshDiscoveryFailed = view.findViewById(R.id.swiperefresh_discovery_failed);
         mSwipeRefreshServicesDisplaying = view.findViewById(R.id.swiperefresh_services_displaying);
 
@@ -86,7 +86,7 @@ public class MdnsDiscoveryFragment extends Fragment {
                     @Override
                     public void onRefresh() {
 
-                        mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+                        mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
                         mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                         mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
 
@@ -108,6 +108,20 @@ public class MdnsDiscoveryFragment extends Fragment {
 
                         if (mSwipeRefreshServicesDisplaying.isRefreshing()) {
                             mSwipeRefreshServicesDisplaying.setRefreshing(false);
+                        }
+                    }
+                }
+        );
+
+        mSwipeRefreshServiceSearch.setOnRefreshListener(
+                new SwipeRefreshLayout.OnRefreshListener() {
+                    @Override
+                    public void onRefresh() {
+
+                        //do nothing ;)
+
+                        if (mSwipeRefreshServiceSearch.isRefreshing()) {
+                            mSwipeRefreshServiceSearch.setRefreshing(false);
                         }
                     }
                 }
@@ -150,7 +164,7 @@ public class MdnsDiscoveryFragment extends Fragment {
             public void onDiscoveryStartFailure() {
                 displayOkAlertDialog(R.string.service_discovery_start_fail_title, R.string.service_discovery_start_fail_message);
 
-                mLinearLayoutServiceSearch.setVisibility(View.GONE);
+                mSwipeRefreshServiceSearch.setVisibility(View.GONE);
                 mSwipeRefreshDiscoveryFailed.setVisibility(View.VISIBLE);
                 mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
             }
@@ -158,11 +172,11 @@ public class MdnsDiscoveryFragment extends Fragment {
             @Override
             public void onListEmptyStatusChange(boolean empty) {
                 if (empty) {
-                    mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+                    mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
                     mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                     mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
                 } else {
-                    mLinearLayoutServiceSearch.setVisibility(View.GONE);
+                    mSwipeRefreshServiceSearch.setVisibility(View.GONE);
                     mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                     mSwipeRefreshServicesDisplaying.setVisibility(View.VISIBLE);
                 }
@@ -191,7 +205,7 @@ public class MdnsDiscoveryFragment extends Fragment {
 
         super.onPause();
 
-        mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+        mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
         mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
         mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListAdapter.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListAdapter.java
@@ -41,11 +41,13 @@ public class ServicesListAdapter extends RecyclerView.Adapter<ServicesListAdapte
 
     // stores and recycles views as they are scrolled off screen
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
-        TextView genericTextView;
+        TextView serviceNameTextView;
+        TextView groupUidTextView;
 
         ViewHolder(View itemView) {
             super(itemView);
-            genericTextView = itemView.findViewById(R.id.serviceName);
+            serviceNameTextView = itemView.findViewById(R.id.serviceName);
+            groupUidTextView = itemView.findViewById(R.id.groupUid);
             itemView.setOnClickListener(this);
         }
 
@@ -75,8 +77,10 @@ public class ServicesListAdapter extends RecyclerView.Adapter<ServicesListAdapte
     // binds the data to the TextView in each row
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        String serviceName = mData.get(position).getGroupName();
-        holder.genericTextView.setText(serviceName);
+        ResolvedGroup groupInfo = mData.get(position);
+
+        holder.groupUidTextView.setText(groupInfo.getGroupUid());
+        holder.serviceNameTextView.setText(groupInfo.getGroupName());
     }
 
     // total number of rows

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
@@ -128,7 +128,8 @@ public class ServicesListView extends RecyclerView {
 
     public void startDiscovery(ServicesListListener servicesListListener) {
         mServicesListListener = servicesListListener;
-        mMdnsDiscovery.discoverServices();
+        //mMdnsDiscovery.discoverServices();
+        mServicesListListener.onDiscoveryStartFailure();
     }
 
     public void stopDiscovery() {

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
@@ -128,8 +128,7 @@ public class ServicesListView extends RecyclerView {
 
     public void startDiscovery(ServicesListListener servicesListListener) {
         mServicesListListener = servicesListListener;
-        //mMdnsDiscovery.discoverServices();
-        mServicesListListener.onDiscoveryStartFailure();
+        mMdnsDiscovery.discoverServices();
     }
 
     public void stopDiscovery() {

--- a/babble/src/main/res/layout/fragment_archived_groups.xml
+++ b/babble/src/main/res/layout/fragment_archived_groups.xml
@@ -27,6 +27,27 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/linearLayout_archive_loading"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <ProgressBar
+            android:id="@+id/progressBar_archive_loading"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/textView_archive_loading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/loading_archive"
+            android:textAlignment="center" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_archived_groups"
         android:layout_width="match_parent"

--- a/babble/src/main/res/layout/fragment_archived_groups.xml
+++ b/babble/src/main/res/layout/fragment_archived_groups.xml
@@ -52,4 +52,19 @@
         android:id="@+id/rv_archived_groups"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout_no_archives"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textView_no_archives"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/no_archives_found"
+            android:textAlignment="center" />
+    </LinearLayout>
 </LinearLayout>

--- a/babble/src/main/res/layout/fragment_mdns_discovery.xml
+++ b/babble/src/main/res/layout/fragment_mdns_discovery.xml
@@ -82,7 +82,7 @@
         android:layout_height="match_parent"
         android:visibility="gone">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true">
@@ -95,7 +95,7 @@
                 android:text="@string/discovery_start_failed"
                 android:textAlignment="center" />
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/babble/src/main/res/layout/fragment_mdns_discovery.xml
+++ b/babble/src/main/res/layout/fragment_mdns_discovery.xml
@@ -42,26 +42,39 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <LinearLayout
-        android:id="@+id/linearLayout_service_search"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh_service_search"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical">
 
-        <ProgressBar
-            android:id="@+id/progressBar_service_search"
-            style="?android:attr/progressBarStyle"
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+            <LinearLayout
+                android:id="@+id/linearLayout_service_search"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/textView_service_search"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/searching_services"
-            android:textAlignment="center" />
-    </LinearLayout>
+                <ProgressBar
+                    android:id="@+id/progressBar_service_search"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <TextView
+                    android:id="@+id/textView_service_search"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/searching_services"
+                    android:textAlignment="center" />
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swiperefresh_discovery_failed"

--- a/babble/src/main/res/layout/service_recyclerview_row.xml
+++ b/babble/src/main/res/layout/service_recyclerview_row.xml
@@ -58,7 +58,7 @@
 
 
         <TextView
-            android:id="@+id/groupID"
+            android:id="@+id/groupUid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="12"

--- a/babble/src/main/res/layout/service_recyclerview_row.xml
+++ b/babble/src/main/res/layout/service_recyclerview_row.xml
@@ -61,6 +61,7 @@
             android:id="@+id/groupUid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorPrimary"
             android:text="12"
             android:textSize="14sp" />
 

--- a/babble/src/main/res/values/colors.xml
+++ b/babble/src/main/res/values/colors.xml
@@ -26,4 +26,5 @@
 <resources>
     <color name="colorSelect">#a6d4f3</color>
     <color name="colorGroupBackground">#c0bebc</color>
+    <color name="colorArchivedGroup">#c0bebc</color>
 </resources>

--- a/babble/src/main/res/values/strings.xml
+++ b/babble/src/main/res/values/strings.xml
@@ -56,4 +56,6 @@
     <string name="loading_archive">Loading archive</string>
     <string name="archive_load_fail_title">Unable to load archive</string>
     <string name="archive_load_fail_message">Please try again later!</string>
+    <string name="no_archives_found">There are no archives to view</string>
+
 </resources>

--- a/babble/src/main/res/values/strings.xml
+++ b/babble/src/main/res/values/strings.xml
@@ -53,4 +53,7 @@
     <string name="live_tab">LIVE</string>
     <string name="archived_tab">ARCHIVED</string>
     <string name="delete">delete</string>
+    <string name="loading_archive">Loading archive</string>
+    <string name="archive_load_fail_title">Unable to load archive</string>
+    <string name="archive_load_fail_message">Please try again later!</string>
 </resources>

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
@@ -71,6 +71,12 @@ public class ChatActivity extends AppCompatActivity implements ServiceObserver {
 
         if (mArchiveMode) {
             stateUpdated();
+
+            if (mMessageIndex==0) {
+                findViewById(R.id.relativeLayout_messages).setVisibility(View.GONE);
+                findViewById(R.id.linearLayout_empty_archive).setVisibility(View.VISIBLE);
+            }
+
         } else {
             if (!mMessagingService.isAdvertising()) {
                 Toast.makeText(this, "Unable to advertise peers", Toast.LENGTH_LONG).show();

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
@@ -71,10 +71,10 @@ public class ChatActivity extends AppCompatActivity implements ServiceObserver {
 
         if (mArchiveMode) {
             stateUpdated();
-        }
-
-        if (!mMessagingService.isAdvertising()) {
-            Toast.makeText(this, "Unable to advertise peers", Toast.LENGTH_LONG).show();
+        } else {
+            if (!mMessagingService.isAdvertising()) {
+                Toast.makeText(this, "Unable to advertise peers", Toast.LENGTH_LONG).show();
+            }
         }
     }
 

--- a/sample/src/main/res/layout/activity_chat.xml
+++ b/sample/src/main/res/layout/activity_chat.xml
@@ -23,35 +23,61 @@
   ~ SOFTWARE.
   -->
 
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/LinearLayout_parent"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
-    tools:context=".ChatActivity">
+    android:gravity="center"
+    android:orientation="vertical">
 
-    <com.stfalcon.chatkit.messages.MessagesList
-        android:id="@+id/messagesList"
+    <RelativeLayout
+        android:id="@+id/relativeLayout_messages"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/input"/>
+        android:background="@color/white"
+        tools:context=".ChatActivity">
 
-    <View
+        <com.stfalcon.chatkit.messages.MessagesList
+            android:id="@+id/messagesList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@+id/input"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_above="@+id/input"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:background="@color/gray_light"/>
+
+        <com.stfalcon.chatkit.messages.MessageInput
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            app:inputHint="@string/hint_enter_a_message"
+            app:showAttachmentButton="true"/>
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout_empty_archive"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_above="@+id/input"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:background="@color/gray_light"/>
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:gravity="center"
+        android:orientation="vertical">
 
-    <com.stfalcon.chatkit.messages.MessageInput
-        android:id="@+id/input"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        app:inputHint="@string/hint_enter_a_message"
-        app:showAttachmentButton="true"/>
+        <TextView
+            android:id="@+id/textView_empty_archive"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/no_messages_in_archive"
+            android:textAlignment="center" />
+    </LinearLayout>
 
-</RelativeLayout>
+</LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -25,5 +25,6 @@
 <resources>
     <string name="app_name">BabbleSample</string>
     <string name="hint_enter_a_message">Enter a message</string>
+    <string name="no_messages_in_archive">This archive is empty</string>
 
 </resources>


### PR DESCRIPTION
This branch contains a number of UI and UX changes:

- Group UID is displayed in the live groups list
- Added group UID to archive view. Changed text colour of backup archives to light gray.
- Display message if archive is empty in Sample app ChatActivity
- Display message if no archives found
- Add swipe refresh on mDNS service search
- Fix bug when refreshing after mDNS start failure
