### PR TITLE
Ui cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## UNRELEASED
+
+SECURITY:
+
+FEATURES:
+
+IMPROVEMENTS:
+
+- group UID is now displayed in the live groups list
+- added group UID to archive view and changed text colour of backup archives to light gray
+- display a message if archive is empty in Sample app ChatActivity
+- display message if no archives found
+- add swipe refresh on mDNS service search
+
+BUG FIXES:
+
+- Fix bug when refreshing after mDNS start failure
+
 ## v0.3.1 (February 10, 2020)
 
 SECURITY:

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -359,11 +359,13 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
 
     // stores and recycles views as they are scrolled off screen
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
-        TextView genericTextView;
+        TextView groupNameTextView;
+        TextView groupUidTextView;
 
         ViewHolder(View itemView) {
             super(itemView);
-            genericTextView = itemView.findViewById(R.id.serviceName);
+            groupNameTextView = itemView.findViewById(R.id.serviceName);
+            groupUidTextView = itemView.findViewById(R.id.groupUid);
             itemView.setOnClickListener(this);
             itemView.setOnLongClickListener(this);
         }
@@ -384,13 +386,14 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
     private List<ConfigDirectory> mData;
     private LayoutInflater mInflater;
     private ItemClickListener mClickListener;
+    private Context mContext;
 
     public ArchivedGroupsAdapter(Context context, List<ConfigDirectory> data) {
         this.mInflater = LayoutInflater.from(context);
         this.mData = data;
+        mContext = context;
     }
 
-    // inflates the row layout from xml when needed
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -398,15 +401,29 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
         return new ViewHolder(view);
     }
 
-    // binds the data to the TextView in each row
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        String serviceName = mData.get(position).description;
+        ConfigDirectory configDirectory = mData.get(position);
+        String serviceName = configDirectory.description;
+        String groupUid = configDirectory.uniqueId;
 
-        holder.genericTextView.setText(serviceName);
+        holder.groupNameTextView.setText(serviceName);
+        holder.groupUidTextView.setText(groupUid);
+
+        int colourGroupName;
+        int colourGroupUid;
+        if (configDirectory.isBackup) {
+            colourGroupName = R.color.colorArchivedGroup;
+            colourGroupUid = R.color.colorArchivedGroup;
+        } else {
+            colourGroupName = android.R.color.primary_text_light;
+            colourGroupUid = android.R.color.secondary_text_light;
+        }
+
+        holder.groupNameTextView.setTextColor(mContext.getResources().getColor(colourGroupName));
+        holder.groupUidTextView.setTextColor(mContext.getResources().getColor(colourGroupUid));
     }
 
-    // total number of rows
     @Override
     public int getItemCount() {
         if (mData == null) {
@@ -416,12 +433,10 @@ class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.V
         }
     }
 
-    // convenience method for getting data at click position
     public ConfigDirectory getItem(int id) {
         return mData.get(id);
     }
 
-    // allows clicks events to be caught
     public void setClickListener(ItemClickListener itemClickListener) {
         this.mClickListener = itemClickListener;
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -77,6 +77,7 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
     private ArchivedGroupsViewModel mViewModel;
     private RecyclerView mRvArchivedGroups;
     private LinearLayout mLinearLayoutArchiveLoading;
+    private LinearLayout mLinearLayoutNoArchives;
     private Boolean mSelected;
 
 
@@ -129,6 +130,7 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
         mRvArchivedGroups.setAdapter(mArchivedGroupsAdapter);
 
         mLinearLayoutArchiveLoading = view.findViewById(R.id.linearLayout_archive_loading);
+        mLinearLayoutNoArchives = view.findViewById(R.id.linearLayout_no_archives);
 
         final Observer<ArchivedGroupsViewModel.State> viewModelState = new Observer<ArchivedGroupsViewModel.State>() {
             @Override
@@ -146,8 +148,15 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
 
         switch (state) {
             case LIST:
-                mRvArchivedGroups.setVisibility(View.VISIBLE);
-                mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                if (mArchivedList.isEmpty()) {
+                    mLinearLayoutNoArchives.setVisibility(View.VISIBLE);
+                    mRvArchivedGroups.setVisibility(View.GONE);
+                    mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                } else {
+                    mLinearLayoutNoArchives.setVisibility(View.GONE);
+                    mRvArchivedGroups.setVisibility(View.VISIBLE);
+                    mLinearLayoutArchiveLoading.setVisibility(View.GONE);
+                }
                 break;
             case LOADING:
                 mRvArchivedGroups.setVisibility(View.GONE);
@@ -259,6 +268,12 @@ public class ArchivedGroupsFragment extends Fragment implements ArchivedGroupsAd
                     for (ConfigDirectory configDirectory: mSelectedGroupsConfigs) {
                         mConfigManager.deleteDirectoryAndBackups(configDirectory.directoryName, false);
                         mArchivedList.remove(configDirectory);
+                    }
+
+                    if (mArchivedList.isEmpty()) {
+                        mLinearLayoutNoArchives.setVisibility(View.VISIBLE);
+                        mRvArchivedGroups.setVisibility(View.GONE);
+                        mLinearLayoutArchiveLoading.setVisibility(View.GONE);
                     }
 
                     mArchivedGroupsAdapter.notifyDataSetChanged();

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/MdnsDiscoveryFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/MdnsDiscoveryFragment.java
@@ -48,7 +48,7 @@ public class MdnsDiscoveryFragment extends Fragment {
 
     private OnFragmentInteractionListener mListener;
     private ServicesListView mServiceListView;
-    private LinearLayout mLinearLayoutServiceSearch;
+    public SwipeRefreshLayout mSwipeRefreshServiceSearch;
     private SwipeRefreshLayout mSwipeRefreshDiscoveryFailed;
     private SwipeRefreshLayout mSwipeRefreshServicesDisplaying;
 
@@ -77,7 +77,7 @@ public class MdnsDiscoveryFragment extends Fragment {
         final View view = inflater.inflate(R.layout.fragment_mdns_discovery, container, false);
 
         mServiceListView = view.findViewById(R.id.servicesListView);
-        mLinearLayoutServiceSearch = view.findViewById(R.id.linearLayout_service_search);
+        mSwipeRefreshServiceSearch = view.findViewById(R.id.swipeRefresh_service_search);
         mSwipeRefreshDiscoveryFailed = view.findViewById(R.id.swiperefresh_discovery_failed);
         mSwipeRefreshServicesDisplaying = view.findViewById(R.id.swiperefresh_services_displaying);
 
@@ -86,7 +86,7 @@ public class MdnsDiscoveryFragment extends Fragment {
                     @Override
                     public void onRefresh() {
 
-                        mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+                        mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
                         mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                         mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
 
@@ -108,6 +108,20 @@ public class MdnsDiscoveryFragment extends Fragment {
 
                         if (mSwipeRefreshServicesDisplaying.isRefreshing()) {
                             mSwipeRefreshServicesDisplaying.setRefreshing(false);
+                        }
+                    }
+                }
+        );
+
+        mSwipeRefreshServiceSearch.setOnRefreshListener(
+                new SwipeRefreshLayout.OnRefreshListener() {
+                    @Override
+                    public void onRefresh() {
+
+                        //do nothing ;)
+
+                        if (mSwipeRefreshServiceSearch.isRefreshing()) {
+                            mSwipeRefreshServiceSearch.setRefreshing(false);
                         }
                     }
                 }
@@ -150,7 +164,7 @@ public class MdnsDiscoveryFragment extends Fragment {
             public void onDiscoveryStartFailure() {
                 displayOkAlertDialog(R.string.service_discovery_start_fail_title, R.string.service_discovery_start_fail_message);
 
-                mLinearLayoutServiceSearch.setVisibility(View.GONE);
+                mSwipeRefreshServiceSearch.setVisibility(View.GONE);
                 mSwipeRefreshDiscoveryFailed.setVisibility(View.VISIBLE);
                 mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
             }
@@ -158,11 +172,11 @@ public class MdnsDiscoveryFragment extends Fragment {
             @Override
             public void onListEmptyStatusChange(boolean empty) {
                 if (empty) {
-                    mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+                    mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
                     mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                     mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
                 } else {
-                    mLinearLayoutServiceSearch.setVisibility(View.GONE);
+                    mSwipeRefreshServiceSearch.setVisibility(View.GONE);
                     mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
                     mSwipeRefreshServicesDisplaying.setVisibility(View.VISIBLE);
                 }
@@ -191,7 +205,7 @@ public class MdnsDiscoveryFragment extends Fragment {
 
         super.onPause();
 
-        mLinearLayoutServiceSearch.setVisibility(View.VISIBLE);
+        mSwipeRefreshServiceSearch.setVisibility(View.VISIBLE);
         mSwipeRefreshDiscoveryFailed.setVisibility(View.GONE);
         mSwipeRefreshServicesDisplaying.setVisibility(View.GONE);
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListAdapter.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListAdapter.java
@@ -41,11 +41,13 @@ public class ServicesListAdapter extends RecyclerView.Adapter<ServicesListAdapte
 
     // stores and recycles views as they are scrolled off screen
     public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
-        TextView genericTextView;
+        TextView serviceNameTextView;
+        TextView groupUidTextView;
 
         ViewHolder(View itemView) {
             super(itemView);
-            genericTextView = itemView.findViewById(R.id.serviceName);
+            serviceNameTextView = itemView.findViewById(R.id.serviceName);
+            groupUidTextView = itemView.findViewById(R.id.groupUid);
             itemView.setOnClickListener(this);
         }
 
@@ -75,8 +77,10 @@ public class ServicesListAdapter extends RecyclerView.Adapter<ServicesListAdapte
     // binds the data to the TextView in each row
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        String serviceName = mData.get(position).getGroupName();
-        holder.genericTextView.setText(serviceName);
+        ResolvedGroup groupInfo = mData.get(position);
+
+        holder.groupUidTextView.setText(groupInfo.getGroupUid());
+        holder.serviceNameTextView.setText(groupInfo.getGroupName());
     }
 
     // total number of rows

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
@@ -128,7 +128,8 @@ public class ServicesListView extends RecyclerView {
 
     public void startDiscovery(ServicesListListener servicesListListener) {
         mServicesListListener = servicesListListener;
-        mMdnsDiscovery.discoverServices();
+        //mMdnsDiscovery.discoverServices();
+        mServicesListListener.onDiscoveryStartFailure();
     }
 
     public void stopDiscovery() {

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ServicesListView.java
@@ -128,8 +128,7 @@ public class ServicesListView extends RecyclerView {
 
     public void startDiscovery(ServicesListListener servicesListListener) {
         mServicesListListener = servicesListListener;
-        //mMdnsDiscovery.discoverServices();
-        mServicesListListener.onDiscoveryStartFailure();
+        mMdnsDiscovery.discoverServices();
     }
 
     public void stopDiscovery() {

--- a/babble/src/main/res/layout/fragment_archived_groups.xml
+++ b/babble/src/main/res/layout/fragment_archived_groups.xml
@@ -52,4 +52,19 @@
         android:id="@+id/rv_archived_groups"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout_no_archives"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textView_no_archives"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/no_archives_found"
+            android:textAlignment="center" />
+    </LinearLayout>
 </LinearLayout>

--- a/babble/src/main/res/layout/fragment_mdns_discovery.xml
+++ b/babble/src/main/res/layout/fragment_mdns_discovery.xml
@@ -82,7 +82,7 @@
         android:layout_height="match_parent"
         android:visibility="gone">
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fillViewport="true">
@@ -95,7 +95,7 @@
                 android:text="@string/discovery_start_failed"
                 android:textAlignment="center" />
 
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 

--- a/babble/src/main/res/layout/fragment_mdns_discovery.xml
+++ b/babble/src/main/res/layout/fragment_mdns_discovery.xml
@@ -42,26 +42,39 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <LinearLayout
-        android:id="@+id/linearLayout_service_search"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh_service_search"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical">
 
-        <ProgressBar
-            android:id="@+id/progressBar_service_search"
-            style="?android:attr/progressBarStyle"
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="match_parent"
+            android:fillViewport="true">
+            <LinearLayout
+                android:id="@+id/linearLayout_service_search"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/textView_service_search"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/searching_services"
-            android:textAlignment="center" />
-    </LinearLayout>
+                <ProgressBar
+                    android:id="@+id/progressBar_service_search"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+                <TextView
+                    android:id="@+id/textView_service_search"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/searching_services"
+                    android:textAlignment="center" />
+            </LinearLayout>
+        </androidx.core.widget.NestedScrollView>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swiperefresh_discovery_failed"

--- a/babble/src/main/res/layout/service_recyclerview_row.xml
+++ b/babble/src/main/res/layout/service_recyclerview_row.xml
@@ -58,7 +58,7 @@
 
 
         <TextView
-            android:id="@+id/groupID"
+            android:id="@+id/groupUid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="12"

--- a/babble/src/main/res/layout/service_recyclerview_row.xml
+++ b/babble/src/main/res/layout/service_recyclerview_row.xml
@@ -61,6 +61,7 @@
             android:id="@+id/groupUid"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textColor="?android:attr/textColorPrimary"
             android:text="12"
             android:textSize="14sp" />
 

--- a/babble/src/main/res/values/colors.xml
+++ b/babble/src/main/res/values/colors.xml
@@ -26,4 +26,5 @@
 <resources>
     <color name="colorSelect">#a6d4f3</color>
     <color name="colorGroupBackground">#c0bebc</color>
+    <color name="colorArchivedGroup">#c0bebc</color>
 </resources>

--- a/babble/src/main/res/values/strings.xml
+++ b/babble/src/main/res/values/strings.xml
@@ -56,4 +56,6 @@
     <string name="loading_archive">Loading archive</string>
     <string name="archive_load_fail_title">Unable to load archive</string>
     <string name="archive_load_fail_message">Please try again later!</string>
+    <string name="no_archives_found">There are no archives to view</string>
+
 </resources>

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
@@ -71,6 +71,12 @@ public class ChatActivity extends AppCompatActivity implements ServiceObserver {
 
         if (mArchiveMode) {
             stateUpdated();
+
+            if (mMessageIndex==0) {
+                findViewById(R.id.relativeLayout_messages).setVisibility(View.GONE);
+                findViewById(R.id.linearLayout_empty_archive).setVisibility(View.VISIBLE);
+            }
+
         } else {
             if (!mMessagingService.isAdvertising()) {
                 Toast.makeText(this, "Unable to advertise peers", Toast.LENGTH_LONG).show();

--- a/sample/src/main/res/layout/activity_chat.xml
+++ b/sample/src/main/res/layout/activity_chat.xml
@@ -23,35 +23,61 @@
   ~ SOFTWARE.
   -->
 
-<RelativeLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/LinearLayout_parent"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"
-    tools:context=".ChatActivity">
+    android:gravity="center"
+    android:orientation="vertical">
 
-    <com.stfalcon.chatkit.messages.MessagesList
-        android:id="@+id/messagesList"
+    <RelativeLayout
+        android:id="@+id/relativeLayout_messages"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/input"/>
+        android:background="@color/white"
+        tools:context=".ChatActivity">
 
-    <View
+        <com.stfalcon.chatkit.messages.MessagesList
+            android:id="@+id/messagesList"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_above="@+id/input"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_above="@+id/input"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:background="@color/gray_light"/>
+
+        <com.stfalcon.chatkit.messages.MessageInput
+            android:id="@+id/input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            app:inputHint="@string/hint_enter_a_message"
+            app:showAttachmentButton="true"/>
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout_empty_archive"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_above="@+id/input"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:background="@color/gray_light"/>
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:gravity="center"
+        android:orientation="vertical">
 
-    <com.stfalcon.chatkit.messages.MessageInput
-        android:id="@+id/input"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        app:inputHint="@string/hint_enter_a_message"
-        app:showAttachmentButton="true"/>
+        <TextView
+            android:id="@+id/textView_empty_archive"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/no_messages_in_archive"
+            android:textAlignment="center" />
+    </LinearLayout>
 
-</RelativeLayout>
+</LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -25,5 +25,6 @@
 <resources>
     <string name="app_name">BabbleSample</string>
     <string name="hint_enter_a_message">Enter a message</string>
+    <string name="no_messages_in_archive">This archive is empty</string>
 
 </resources>


### PR DESCRIPTION
This branch contains a number of UI and UX changes:

- Group UID is displayed in the live groups list
- Added group UID to archive view. Changed text colour of backup archives to light gray.
- Display message if archive is empty in Sample app ChatActivity
- Display message if no archives found
- Add swipe refresh on mDNS service search
- Fix bug when refreshing after mDNS start failure
