### PR TITLE
Prevent app from crashing if WiFi is turned off

### DIFF
--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/JoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/JoinGroupFragment.java
@@ -208,8 +208,9 @@ public class JoinGroupFragment extends Fragment implements ResponseListener {
         } catch (IllegalStateException | CannotStartBabbleNodeException| IOException ex ) {
             //TODO: just catch IOException - this will mean the port is in use
             //we'll assume this is caused by the node taking a while to leave a previous group,
-            //though it could be that another application is using the port - in which case
-            //we'll keep getting stuck here until the port is available!
+            //though it could be that another application is using the port or WiFi is turned off -
+            // in which case we'll keep getting stuck here until the port is available or WiFi is
+            // turned on!
             mLoadingDialog.dismiss();
             displayOkAlertDialog(R.string.babble_init_fail_title, R.string.babble_init_fail_message);
             return;

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
@@ -181,15 +181,18 @@ public class NewGroupFragment extends Fragment {
 
 
         try {
+            Log.d("BUG-HUNT", "startGroup: ");
             babbleService.start(configDirectory, groupDescriptor);
-            mListener.onStartedNew(moniker);
-        } catch (Exception ex) {
-            //TODO: Review this. The duplicate dialog function feels overkill.
-            displayOkAlertDialogText(R.string.babble_init_fail_title, "Cannot start babble: "+ ex.getClass().getCanonicalName()+": "+ ex.getMessage() );
-            throw ex;
+        } catch (IllegalArgumentException ex) {
+            //we'll assume this is caused by the node taking a while to leave a previous group,
+            //though it could be that another application is using the port or WiFi is turned off -
+            // in which case we'll keep getting stuck here until the port is available or WiFi is
+            // turned on!
+            displayOkAlertDialog(R.string.babble_init_fail_title, R.string.babble_init_fail_message);
+            return;
         }
 
-
+        mListener.onStartedNew(moniker);
     }
 
 


### PR DESCRIPTION
When starting a new group the app would crash if any exceptions were thrown when
starting the Babble service. This change catches IllegalArgumentExceptions which
can be caused by the port being in use or if the WiFi is turned off. The port
may be in use because we are waiting fo a leave to complete. Inside the catch a
dialog is displayed suggesting to the user that they wait a few seconds and
check their WiFi connection.