### PR TITLE
Improvements and fixes to archive display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## UNRELEASED
+
+SECURITY:
+
+FEATURES:
+
+IMPROVEMENTS:
+
+- archive: Maintain group selections through configuration changes
+- archive: Remove contextual action bar when changing to another tab
+
+BUG FIXES:
+
+- archive: Select only one group on long click. Previously when long clicking
+  an archived group, every n'th group would be selected
 
 ## v0.4.1 (February 28, 2020)
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsAdapter.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsAdapter.java
@@ -1,0 +1,141 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.configure;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import io.mosaicnetworks.babble.R;
+import io.mosaicnetworks.babble.node.ConfigDirectory;
+
+class ArchivedGroupsAdapter extends RecyclerView.Adapter<ArchivedGroupsAdapter.ViewHolder> {
+
+    private SelectableData<ConfigDirectory> mData;
+    private LayoutInflater mInflater;
+    private ItemClickListener mClickListener;
+    private Context mContext;
+
+    public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
+        TextView groupNameTextView;
+        TextView groupUidTextView;
+        private View mView;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+            groupNameTextView = itemView.findViewById(R.id.serviceName);
+            groupUidTextView = itemView.findViewById(R.id.groupUid);
+            itemView.setOnClickListener(this);
+            itemView.setOnLongClickListener(this);
+            mView = itemView;
+        }
+
+        public void setSelected(Boolean selected) {
+            mView.setSelected(selected);
+        }
+
+        @Override
+        public void onClick(View view) {
+            if (mClickListener != null) mClickListener.onItemShortClick(view, getAdapterPosition());
+        }
+
+        @Override
+        public boolean onLongClick(View view) {
+            if (mClickListener != null) mClickListener.onItemLongClick(view, getAdapterPosition());
+
+            // Return true to indicate the click was handled
+            return true;
+        }
+    }
+
+    public ArchivedGroupsAdapter(Context context, SelectableData<ConfigDirectory> data) {
+        mInflater = LayoutInflater.from(context);
+        mData = data;
+        mContext = context;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = mInflater.inflate(R.layout.service_recyclerview_row, parent, false);
+
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder holder, int position) {
+        ConfigDirectory configDirectory = mData.get(position);
+        String serviceName = configDirectory.description;
+        String groupUid = configDirectory.uniqueId;
+
+        holder.groupNameTextView.setText(serviceName);
+        holder.groupUidTextView.setText(groupUid);
+
+        int colourGroupName;
+        int colourGroupUid;
+        if (configDirectory.isBackup) {
+            colourGroupName = R.color.colorArchivedGroup;
+            colourGroupUid = R.color.colorArchivedGroup;
+        } else {
+            colourGroupName = android.R.color.primary_text_light;
+            colourGroupUid = android.R.color.secondary_text_light;
+        }
+
+        holder.groupNameTextView.setTextColor(mContext.getResources().getColor(colourGroupName));
+        holder.groupUidTextView.setTextColor(mContext.getResources().getColor(colourGroupUid));
+
+        if (mData.isSelected(position)) {
+            holder.setSelected(true);
+        } else {
+            holder.setSelected(false);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        if (mData == null) {
+            return 0;
+        } else {
+            return mData.size();
+        }
+    }
+
+    public void setClickListener(ItemClickListener itemClickListener) {
+        this.mClickListener = itemClickListener;
+    }
+
+    // parent activity will implement these methods to respond to click events
+    public interface ItemClickListener {
+
+        void onItemShortClick(View view, int position);
+
+        void onItemLongClick(View view, int position);
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModelFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsViewModelFactory.java
@@ -27,19 +27,18 @@ package io.mosaicnetworks.babble.configure;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
-import io.mosaicnetworks.babble.node.BabbleService;
+import io.mosaicnetworks.babble.node.ConfigManager;
 
 public class ArchivedGroupsViewModelFactory implements ViewModelProvider.Factory {
+    private ConfigManager mConfigManager;
 
-    private BabbleService mBabbleService;
-
-    public ArchivedGroupsViewModelFactory(BabbleService babbleService) {
-        mBabbleService = babbleService;
+    public ArchivedGroupsViewModelFactory(ConfigManager configManager) {
+        mConfigManager = configManager;
     }
 
     @Override
     @SuppressWarnings("unchecked")  //unchecked cast warning caused by the use of generics.
     public <T extends ViewModel> T create(Class<T> modelClass) {
-        return (T) new ArchivedGroupsViewModel(mBabbleService);
+        return (T) new ArchivedGroupsViewModel(mConfigManager);
     }
 }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -182,17 +182,6 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
     }
 
     @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-
-        // If an archive is loading and the user presses the back button. This activity will be
-        // destroyed, if in the meantime the service transitions into the "ARCHIVE" state, when the
-        // app is restarted the service won't be in the "STOPPED" or "ARCHIVE-INIT" state which this
-        // activity expects
-        getBabbleService().stop();
-    }
-
-    @Override
     public void onServiceSelected(ResolvedGroup resolvedGroup) {
 
         if (resolvedGroup instanceof MdnsResolvedGroup) {
@@ -226,6 +215,7 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
         super.onStart();
         if (mFromGroup) {
             mFragmentManager.popBackStack();
+            ArchivedGroupsFragment.reloadArchive = true;
             mFromGroup = false;
         }
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
@@ -242,19 +242,9 @@ public class NewGroupFragment extends Fragment implements OnNetworkInitialised {
 
         String configDirectory;
 
-
-        try {
             configManager = ConfigManager.getInstance(Objects.requireNonNull(getContext()).getApplicationContext());
 
             Log.v("startGroup", "Got ConfigManager ");
-
-        } catch (FileNotFoundException ex) {
-            //This error is thrown by ConfigManager when it fails to read / create a babble root dir.
-            //This is probably a fatal error.
-            DialogUtils.displayOkAlertDialogText(Objects.requireNonNull(getContext()), R.string.babble_init_fail_title, "Cannot write configuration. Aborting.");
-            throw new IllegalStateException();  // Throws a runtime exception that is deliberately not caught
-            // The app will terminate. But babble is unstartable from here.
-        }
 
 
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/SelectableData.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/SelectableData.java
@@ -1,0 +1,166 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.configure;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Holds a list of objects which, for each object, has a flag denoting whether the object is
+ * selected or not. The selected state is controlled by the user of this class.
+ * @param <T> is the type of the collection of objects
+ */
+public final class SelectableData<T> {
+
+    private final List<T> mData = new ArrayList<>();
+    private final List<Boolean> mSelectedFlags = new ArrayList<>();
+    private final List<Integer> mAllSelected = new ArrayList<>();
+
+    /**
+     * Set selected flag to true for item at the given position
+     * @param position is the item's position in the list
+     */
+    public void select(int position) {
+        if (!mSelectedFlags.get(position)) {
+            mAllSelected.add(position);
+            mSelectedFlags.set(position, true);
+        }
+    }
+
+    /**
+     * Set selected flag to false for item at the given position
+     * @param position is the item's position in the list
+     */
+    public void unSelect(int position) {
+        if (mSelectedFlags.get(position)) {
+            mSelectedFlags.set(position, false);
+            mAllSelected.remove(new Integer(position));
+        }
+    }
+
+    /**
+     * Return whether the item at the given position it selected
+     * @param position is the item's position in the list
+     * @return true if item is selected, otherwise false
+     */
+    public Boolean isSelected(int position) {
+        return mSelectedFlags.get(position);
+    }
+
+    /**
+     * Unselects all items
+     */
+    public void unSelectAll() {
+        for (Integer position:mAllSelected) {
+            mSelectedFlags.set(position, false);
+        }
+
+        mAllSelected.clear();
+    }
+
+    /**
+     * Returns a list of the positions of all the selected items
+     * @return {@Link List} of the positions of all selected items
+     */
+    public List<Integer> getAllSelected() {
+        return new ArrayList<>(mAllSelected); //return a copy so the list cannot be interfered with
+    }
+
+    /**
+     * Returns true if any items are selected, false otherwise
+     * @return tru if any items selected, false otherwise
+     */
+    public boolean anySelected() {
+        return !mAllSelected.isEmpty();
+    }
+
+    /**
+     * Remove all selected items from the list
+     */
+    public void removeAllSelected() {
+        Collections.sort(mAllSelected);
+        Collections.reverse(mAllSelected);
+
+        for (int selPos:mAllSelected) {
+            mData.remove(selPos);
+            mSelectedFlags.remove(selPos);
+        }
+
+        mAllSelected.clear();
+    }
+
+    /**
+     * Return true if the list is empty, false otherwise
+     * @return true if list is empty, false otherwise
+     */
+    public boolean isEmpty() {
+        return mData.isEmpty();
+    }
+
+    /**
+     * Append items to the end of the list
+     * @param items the list of items to append to the list
+     */
+    public void addAll(List<T> items) {
+        mData.addAll(items);
+        mSelectedFlags.addAll(Collections.nCopies(items.size(), false));
+    }
+
+    /**
+     * Append an item to the end of the list
+     * @param item
+     */
+    public void add(T item) {
+        mData.add(item);
+        mSelectedFlags.add(false);
+    }
+
+    /**
+     * Remove all items from the list
+     */
+    public void clear() {
+        mData.clear();
+        mSelectedFlags.clear();
+        mAllSelected.clear();
+    }
+
+    /**
+     * Get item at position
+     * @param position the position of the item to return
+     * @return the item at the specified position
+     */
+    public T get(int position) {
+        return mData.get(position);
+    }
+
+    /**
+     * get the size of the list
+     * @return the size of the list
+     */
+    public int size() {
+        return mData.size();
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsJoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsJoinGroupFragment.java
@@ -210,15 +210,8 @@ public class MdnsJoinGroupFragment extends Fragment implements ResponseListener 
     public void onReceivePeers(List<Peer> currentPeers) {
 
         ConfigManager configManager;
-        try {
             configManager = ConfigManager.getInstance(Objects.requireNonNull(getContext()).getApplicationContext());
-        } catch (FileNotFoundException ex) {
-            //This error is thrown by ConfigManager when it fails to read / create a babble root dir.
-            //This is probably a fatal error.
-            DialogUtils.displayOkAlertDialogText(Objects.requireNonNull(getContext()), R.string.babble_init_fail_title, "Cannot write configuration. Aborting.");
-            throw new IllegalStateException();  // Throws a runtime exception that is deliberately not caught
-            // The app will terminate. But babble is unstartable from here.
-        }
+
 
         BabbleService<?> babbleService = mListener.getBabbleService();
         GroupDescriptor groupDescriptor = new GroupDescriptor(mResolvedService.getGroupName(), mResolvedService.getGroupUid());

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PJoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PJoinGroupFragment.java
@@ -232,15 +232,8 @@ public class P2PJoinGroupFragment extends Fragment implements ResponseListener, 
     public void onReceivePeers(List<Peer> currentPeers) {
 
         ConfigManager configManager;
-        try {
             configManager = ConfigManager.getInstance(Objects.requireNonNull(getContext()).getApplicationContext());
-        } catch (FileNotFoundException ex) {
-            //This error is thrown by ConfigManager when it fails to read / create a babble root dir.
-            //This is probably a fatal error.
-            DialogUtils.displayOkAlertDialogText(Objects.requireNonNull(getContext()), R.string.babble_init_fail_title, "Cannot write configuration. Aborting.");
-            throw new IllegalStateException();  // Throws a runtime exception that is deliberately not caught
-            // The app will terminate. But babble is unstartable from here.
-        }
+
 
         BabbleService<?> babbleService = mListener.getBabbleService();
         GroupDescriptor groupDescriptor = new GroupDescriptor(mResolvedService.getGroupName(), mResolvedService.getGroupUid());

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
@@ -123,7 +123,7 @@ public final class ConfigManager {
      * @param context Context. Used to call getFilesDir to find the path to the babble config dirs
      * @return an instance of ConfigManager
      */
-    public static ConfigManager getInstance(Context context) throws FileNotFoundException {
+    public static ConfigManager getInstance(Context context) {
         if (INSTANCE==null) {
             Log.v("ConfigManager", "getInstance");
             INSTANCE = new ConfigManager(context.getApplicationContext());
@@ -137,7 +137,7 @@ public final class ConfigManager {
      * @param appContext the application context
      * @throws FileNotFoundException when the babble root dir cannot be created
      */
-    private ConfigManager(Context appContext) throws FileNotFoundException{
+    private ConfigManager(Context appContext) {
 
         Log.v("ConfigManager", "constructor");
 
@@ -161,7 +161,7 @@ public final class ConfigManager {
             populateDirectories(babbleDir);
         } else { // First run, so we create the root dir - clearly no sub dirs yet
             if ( ( ! babbleDir.mkdirs() ) && (! babbleDir.exists())) {
-                throw new FileNotFoundException();
+                throw new RuntimeException("Could not make babble config directory");
             }
         }
     }
@@ -292,9 +292,8 @@ public final class ConfigManager {
      *Configure the service to create an archive group, overriding the default ports
      * @param inetAddress the IPv4 address of the interface to which the Babble node will bind
      * @param babblingPort the port used for Babble consensus
-     * @throws IllegalStateException if the service is currently running
      */
-    public String setGroupToArchive(ConfigDirectory configDirectory, String inetAddress, int babblingPort) throws  IOException{
+    public String setGroupToArchive(ConfigDirectory configDirectory, String inetAddress, int babblingPort) {
 
         Log.i("setGroupToArchive", configDirectory.directoryName);
 
@@ -557,7 +556,7 @@ public final class ConfigManager {
      * Amends the Babble Config TOML file. This function relies on mTomlDir being set.
      * @param configHashMapChanges A HashMap object containing the changed config data to be written the Toml File.
      */
-    public void amendTomlSettings(Map<String, Object> configHashMapChanges) throws IOException  {
+    public void amendTomlSettings(Map<String, Object> configHashMapChanges) {
         boolean hasChanged = false;
 
         Map<String, Object> configMap = readTomlFile();
@@ -584,7 +583,7 @@ public final class ConfigManager {
              } catch (IOException e)
             {
                 // Rethrow
-                throw e;
+                throw new RuntimeException("Could not ammend TOML file");
             }
         } else {
             Log.i("amendTomlSettings", "No changes, no write");

--- a/babble/src/main/res/layout/fragment_archived_groups.xml
+++ b/babble/src/main/res/layout/fragment_archived_groups.xml
@@ -27,27 +27,6 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/linearLayout_archive_loading"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:orientation="vertical">
-
-        <ProgressBar
-            android:id="@+id/progressBar_archive_loading"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-        <TextView
-            android:id="@+id/textView_archive_loading"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/loading_archive"
-            android:textAlignment="center" />
-    </LinearLayout>
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_archived_groups"
         android:layout_width="match_parent"
@@ -58,6 +37,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
+        android:visibility="gone"
         android:orientation="vertical">
 
         <TextView

--- a/babble/src/test/java/io/mosaicnetworks/babble/configure/SelectableDataTest.java
+++ b/babble/src/test/java/io/mosaicnetworks/babble/configure/SelectableDataTest.java
@@ -24,34 +24,30 @@
 
 package io.mosaicnetworks.babble.configure;
 
-import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.ViewModel;
+import org.junit.Test;
 
-import io.mosaicnetworks.babble.node.ConfigDirectory;
-import io.mosaicnetworks.babble.node.ConfigManager;
+import java.util.Arrays;
+import java.util.List;
 
-public class ArchivedGroupsViewModel extends ViewModel {
+import static org.junit.Assert.assertEquals;
 
-    private MutableLiveData<SelectableData<ConfigDirectory>> mArchivedList;
-    private ConfigManager mConfigManager;
+public class SelectableDataTest {
 
-    public ArchivedGroupsViewModel(ConfigManager configManager) {
-        super();
-        mConfigManager = configManager;
-
-        mArchivedList = new MutableLiveData<>();
-        loadArchiveList();
+    @Test
+    public void createTest() {
+        SelectableData<Boolean> selectableData = new SelectableData<>();
+        selectableData.addAll(Arrays.asList(new Boolean[]{true, true, false}));
     }
 
-    public void loadArchiveList() {
-        SelectableData<ConfigDirectory> data = new SelectableData<>();
-        data.addAll(mConfigManager.getDirectories());
-        mArchivedList.setValue(data);
-    }
+    @Test
+    public void selectTest() {
+        SelectableData<Boolean> selectableData = new SelectableData<>();
+        selectableData.addAll(Arrays.asList(new Boolean[]{true, true, false}));
+        selectableData.select(1);
 
-    public MutableLiveData<SelectableData<ConfigDirectory>> getArchivedList() {
-        return mArchivedList;
-    }
+        List<Integer> selected = selectableData.getAllSelected();
 
+        assertEquals(1, selected.size());
+        assertEquals(Integer.valueOf(1), selected.get(0));
+    }
 }
-

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivity.java
@@ -134,8 +134,15 @@ public class ChatActivity extends AppCompatActivity implements ServiceObserver {
     @Override
     public void stateUpdated() {
 
-        Log.i("ChatActivity", "stateUpdated");
-
+        if (mMessageIndex==0) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    findViewById(R.id.relativeLayout_messages).setVisibility(View.VISIBLE);
+                    findViewById(R.id.linearLayout_empty_archive).setVisibility(View.GONE);
+                }
+            });
+        }
 
         List<Message> newMessagesTemp = new ArrayList<>();
 


### PR DESCRIPTION
Improve and fix archive display:

 - When long clicking an archived group, every n'th group would be
   selected. Change to only select the clicked group.
 - Maintain group selections through configuration changes.
 - Remove Contextual Action Bar when changing to another tab

A side effect of these changes has been to simplify the
ArchivedGroupsFragment. The archive fragment does not wait for the
archive to load anymore. This has simplified the ArchivedGroupsFragment,
the BaseConfigActivity and the BabbleService but requires some
additional checking in the ChatActity and when returning to the
BaseConfigActivity from a chat.