### PR TITLE
Add BabbleService2 Android Service

### DIFF
--- a/babble/build.gradle
+++ b/babble/build.gradle
@@ -83,6 +83,9 @@ android {
         buildConfigField "String", "GitHash", "\"${getGitHash()}\""
         buildConfigField "String", "GitHashShort", "\"${getGitHashShort()}\""
         buildConfigField "String", "GitBranch", "\"${getGitBranch()}\""
+        buildConfigField "String", "BabbleVersion", "\"${babbleCoreVersion}\""
+        buildConfigField "String", "BabbleRepo", "\"${repository}\""
+        buildConfigField "String", "BabbleMethod", "\"${method}\""
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -210,9 +210,22 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
         mFromGroup = true;
     }
 
+    /*
+    @Override
+    protected void onStop() {
+        super.onStop();
+
+        if (mFromGroup) {
+            mFragmentManager.popBackStack();
+        }
+    }
+
+     */
+
     @Override
     protected void onStart() {
         super.onStart();
+
         if (mFromGroup) {
             mFragmentManager.popBackStack();
             ArchivedGroupsFragment.reloadArchive = true;

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
@@ -252,13 +252,13 @@ public final class ConfigManager {
 
 
 
-    /**b
+    /**
      * Configure the service to create a new group using the default ports
      * @param moniker node moniker
      * @param inetAddress the IPv4 address of the interface to which the Babble node will bind
      * @throws IllegalStateException if the service is currently running
      */
-    public String createConfigNewGroup(GroupDescriptor groupDescriptor, String moniker, String inetAddress)  throws CannotStartBabbleNodeException, IOException {
+    public String createConfigNewGroup(GroupDescriptor groupDescriptor, String moniker, String inetAddress) {
         return createConfigNewGroup(groupDescriptor, moniker, inetAddress, DEFAULT_BABBLING_PORT);
     }
 
@@ -270,7 +270,7 @@ public final class ConfigManager {
      * //@param discoveryPort the port used by the HttpPeerDiscoveryServer //TODO: how to deal with this
      * @throws IllegalStateException if the service is currently running
      */
-    public String createConfigNewGroup(GroupDescriptor groupDescriptor, String moniker, String inetAddress, int babblingPort) throws CannotStartBabbleNodeException, IOException{
+    public String createConfigNewGroup(GroupDescriptor groupDescriptor, String moniker, String inetAddress, int babblingPort) {
         List<Peer> genesisPeers = new ArrayList<>();
         genesisPeers.add(new Peer(mKeyPair.publicKey, inetAddress + ":" + babblingPort, moniker));
         List<Peer> currentPeers = new ArrayList<>();
@@ -354,7 +354,7 @@ public final class ConfigManager {
     }
 
     private String createConfig(List<Peer> genesisPeers, List<Peer> currentPeers, GroupDescriptor groupDescriptor,
-                                String moniker, String inetAddress, int babblingPort) throws CannotStartBabbleNodeException, IOException {
+                                String moniker, String inetAddress, int babblingPort) {
 
         String compositeGroupName = getCompositeConfigDir(groupDescriptor);
 
@@ -446,7 +446,7 @@ public final class ConfigManager {
      * @param compositeGroupName is the sub-directory of the babble sub-directory of the local storage as passed to the constructor
      * @return the composite path where the babble.toml file was written
      */
-    public String writeBabbleTomlFiles(NodeConfig nodeConfig, String compositeGroupName, String inetAddress, int port, String moniker) throws CannotStartBabbleNodeException, IOException {
+    public String writeBabbleTomlFiles(NodeConfig nodeConfig, String compositeGroupName, String inetAddress, int port, String moniker) {
 
         //TODO: add inetAddress, port and moniker to nodeConfig??
         Map<String, Object> babble = new HashMap<>();
@@ -459,7 +459,7 @@ public final class ConfigManager {
             // We have a clash.
             switch (sConfigDirectoryBackupPolicy) {
                 case ABORT:
-                    throw new CannotStartBabbleNodeException("Config directory already exists and we have ABORT policy");
+                    throw new IllegalArgumentException("Config directory already exists and we have ABORT policy");
                 case COMPLETE_BACKUP:
                 case SINGLE_BACKUP:
                     // Rename
@@ -472,7 +472,7 @@ public final class ConfigManager {
         }
 
         if   ( ( ! babbleDir.mkdirs() ) && (! babbleDir.exists())) {
-            throw new CannotStartBabbleNodeException("Cannot create new Config directory (no previous backup)");
+            throw new IllegalArgumentException("Cannot create new Config directory (no previous backup)");
         }
 
         babble.put("datadir", mTomlDir) ;
@@ -535,7 +535,7 @@ public final class ConfigManager {
      * Writes the Babble Config TOML file. This function relies on mTomlDir being set.
      * @param configHashMap A HashMap object containing the config data to be written the Toml File.
      */
-    protected void writeTomlFile(Map<String, Object> configHashMap) throws IOException {
+    protected void writeTomlFile(Map<String, Object> configHashMap) {
         Log.i("writeTomlFile", mTomlDir);
 
         try {
@@ -546,7 +546,7 @@ public final class ConfigManager {
         } catch (IOException e) {
             // Log and rethrow
             Log.e("writeTomlFile", e.toString());
-            throw e;
+            throw new RuntimeException(e.toString());
         }
 
     }
@@ -576,16 +576,9 @@ public final class ConfigManager {
         }
 
         if (hasChanged) {
-            try {
                 writeTomlFile(configMap);
                 Log.i("amendTomlSettings", configMap.toString());
 
-             } catch (IOException e)
-            {
-                // Rethrow
-                throw new RuntimeException("Could not ammend TOML file");
-            }
-        } else {
             Log.i("amendTomlSettings", "No changes, no write");
         }
 
@@ -695,7 +688,7 @@ public final class ConfigManager {
         }
     }
     
-    private void renameConfigDirectory(String oldSubConfigDir, int newSuffix) throws CannotStartBabbleNodeException {
+    private void renameConfigDirectory(String oldSubConfigDir, int newSuffix) {
         File oldFile = new File(sRootDir + File.separator + BABBLE_ROOTDIR + File.separator + oldSubConfigDir);
         File newFile = new File(sRootDir + File.separator + BABBLE_ROOTDIR + File.separator + oldSubConfigDir + newSuffix);
         
@@ -704,11 +697,11 @@ public final class ConfigManager {
         
         if (!(oldFile.renameTo(newFile))) {
             Log.d("Rename ","Fails");
-            throw new CannotStartBabbleNodeException("Cannot backup the old configuration directory");
+            throw new RuntimeException("Cannot backup the old configuration directory");
         }
     }
 
-    private void backupOldConfigs(String compositeName) throws CannotStartBabbleNodeException {
+    private void backupOldConfigs(String compositeName) {
         
         if (sConfigDirectoryBackupPolicy == ConfigDirectoryBackupPolicy.SINGLE_BACKUP) {
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleService2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleService2.java
@@ -1,0 +1,328 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.service;
+
+import android.annotation.TargetApi;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.os.Binder;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.mosaicnetworks.babble.node.BabbleNode;
+import io.mosaicnetworks.babble.node.BabbleService;
+import io.mosaicnetworks.babble.node.BabbleState;
+import io.mosaicnetworks.babble.node.BabbleTx;
+import io.mosaicnetworks.babble.node.Block;
+import io.mosaicnetworks.babble.node.BlockConsumer;
+import io.mosaicnetworks.babble.node.GroupDescriptor;
+import io.mosaicnetworks.babble.node.LeaveResponseListener;
+import io.mosaicnetworks.babble.node.ServiceObserver;
+
+import static androidx.core.app.NotificationCompat.PRIORITY_LOW;
+
+public class BabbleService2 extends Service {
+
+    public enum State {
+        STOPPED,
+        RUNNING,
+        ARCHIVE,
+    }
+
+    private BabbleNode mBabbleNode;
+    private State mState = State.STOPPED;
+    private GroupDescriptor mGroupDescriptor;
+    private static BabbleState mAppState;
+    private ServiceAdvertiser mServiceAdvertiser;
+    private boolean mIsArchive = false;
+
+    /**
+     * Start the service
+     *
+     * @param configDirectory The full path to the babble configuration directory
+     * @param groupDescriptor The group descriptor
+     * @throws IllegalStateException if the service is currently running
+     */
+    public void start(String configDirectory, GroupDescriptor groupDescriptor,
+                      ServiceAdvertiser serviceAdvertiser) {
+        if (mState!= State.STOPPED) {
+            throw new IllegalStateException("Cannot start service which isn't stopped");
+        }
+
+        mServiceAdvertiser = serviceAdvertiser;
+        mGroupDescriptor = groupDescriptor;
+
+        mBabbleNode = BabbleNode.create(new BlockConsumer() {
+            @Override
+            public Block onReceiveBlock(Block block) {
+                Log.i("ProcessBlock", "Process block");
+                Block processedBlock = mAppState.processBlock(block);
+                notifyObservers();
+                return processedBlock;
+            }
+        }, configDirectory);
+
+        mBabbleNode.run();
+        mServiceAdvertiser.advertise(mBabbleNode.getGenesisPeers(), mBabbleNode.getCurrentPeers());
+        mState = State.RUNNING;
+    }
+
+    /**
+     * This is an asynchronous call to start the service in archive mode
+     * @param configDirectory
+     * @param groupDescriptor
+     */
+    public void startArchive(final String configDirectory, GroupDescriptor groupDescriptor,
+                             final BabbleService.StartArchiveListener listener) {
+        if (mState!=State.STOPPED) {
+            throw new IllegalStateException("Cannot start archive service which isn't stopped");
+        }
+
+        mState = State.ARCHIVE;
+        mIsArchive = true;
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    mBabbleNode = BabbleNode.create(new BlockConsumer() {
+                        @Override
+                        public Block onReceiveBlock(Block block) {
+                            Log.i("ProcessBlock", "Process block");
+                            Block processedBlock = mAppState.processBlock(block);
+                            notifyObservers();
+                            return processedBlock;
+                        }
+                    }, configDirectory);
+
+                } catch (IllegalArgumentException ex) {
+                    //TODO: need more refined Babble exceptions
+                    if (listener!=null) {
+                        listener.onFailed();
+                    }
+                    return;
+                }
+
+                if (listener!=null) {
+                    listener.onInitialised();
+                }
+
+            }
+        }).start();
+
+        mGroupDescriptor = groupDescriptor;
+    }
+
+    public static void setAppState(BabbleState appState) {
+        mAppState = appState;
+    }
+
+    public BabbleState getAppState() {
+        return mAppState;
+    }
+
+    /**
+     * Asynchronous method for leaving a group
+     * @param listener called when the leave completes
+     * @throws IllegalStateException if the service is not currently running
+     */
+    public void leave(final LeaveResponseListener listener) {
+        if (mState== State.STOPPED) {
+            throw new IllegalStateException("Service is not running");
+        }
+
+        mServiceAdvertiser.stopAdvertising();
+
+        if (mBabbleNode==null) {
+            //If an archive fails to load then the babble node can be null
+            mState = State.STOPPED;
+            mGroupDescriptor = null;
+            mAppState.reset();
+            stopSelf();
+
+            if (listener != null) {
+                listener.onComplete();
+            }
+
+        } else {
+
+            mBabbleNode.leave(new LeaveResponseListener() {
+                @Override
+                public void onComplete() {
+                    mBabbleNode = null;
+                    mState = State.STOPPED;
+                    mGroupDescriptor = null;
+                    mAppState.reset();
+                    stopSelf();
+
+                    if (listener != null) {
+                        listener.onComplete();
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Submit a transaction
+     * @param tx the transaction, which must implement {@link BabbleTx}
+     * @throws IllegalStateException if the service is not currently running
+     */
+    public void submitTx(BabbleTx tx) {
+        if (!(mState== State.RUNNING)) {
+            throw new IllegalStateException("Cannot submit when the service isn't running");
+        }
+        mBabbleNode.submitTx(tx.toBytes());
+    }
+
+
+    //###########
+    // service specific stuff
+
+    private static final int NOTIF_ID = 1;
+
+    /**
+     * Class for clients to access.  Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with
+     * IPC.
+     */
+    public class LocalBinder extends Binder {
+        BabbleService2 getService() {
+            return BabbleService2.this;
+        }
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return mBinder;
+    }
+
+    // This is the object that receives interactions from clients.  See
+    // RemoteService for a more complete example.
+    private final IBinder mBinder = new LocalBinder();
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        // do your jobs here
+        //configure();
+        //start();
+
+        startForeground(NOTIF_ID, getNotification());
+
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mServiceAdvertiser.stopAdvertising();
+    }
+
+    //#############
+    // observer stuff
+
+    private List<ServiceObserver> mObservers = new ArrayList<>();;
+
+    /**
+     * Register an observer
+     * @param serviceObserver the observer to be registered, the observer must implement the
+     * {@link ServiceObserver} interface
+     */
+    public void registerObserver(ServiceObserver serviceObserver) {
+        if (!mObservers.contains(serviceObserver)) {
+            mObservers.add(serviceObserver);
+        }
+    }
+
+    /**
+     * Remove an observer
+     * @param messageObserver the observer to be removed, the observer must implement the
+     *                        {@link ServiceObserver} interface
+     */
+    public void removeObserver(ServiceObserver messageObserver) {
+        mObservers.remove(messageObserver);
+    }
+
+    private void notifyObservers() {
+        for (ServiceObserver observer: mObservers) {
+            observer.stateUpdated();
+        }
+    }
+
+    //##############################################################################################
+    // Creating notifications
+
+    public Notification getNotification() {
+        String channel;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            channel = createChannel();
+        else {
+            channel = "";
+        }
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this, channel).setSmallIcon(android.R.drawable.ic_menu_mylocation).setContentTitle("Babble service is running");
+        Notification notification = mBuilder
+                .setPriority(PRIORITY_LOW)
+                .setCategory(Notification.CATEGORY_SERVICE)
+                .build();
+
+
+        return notification;
+    }
+
+    @NonNull
+    @TargetApi(26)
+    private synchronized String createChannel() {
+        NotificationManager mNotificationManager = (NotificationManager) this.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        String name = "snap map fake location ";
+        int importance = NotificationManager.IMPORTANCE_LOW;
+
+        NotificationChannel mChannel = new NotificationChannel("snap map channel", name, importance);
+
+        mChannel.enableLights(true);
+        mChannel.setLightColor(Color.BLUE);
+        if (mNotificationManager != null) {
+            mNotificationManager.createNotificationChannel(mChannel);
+        } else {
+            stopSelf();
+        }
+
+        return "snap map channel";
+
+    }
+
+    //##############################################################################################
+
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleServiceBinder.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleServiceBinder.java
@@ -1,0 +1,92 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.service;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+public abstract class BabbleServiceBinder extends Fragment {
+    // Don't attempt to unbind from the service unless the client has received some
+    // information about the service's state.
+    private boolean mShouldUnbind;
+
+    // To invoke the bound service, first make sure that this value
+    // is not null.
+    protected BabbleService2 mBoundService;
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            // This is called when the connection with the service has been
+            // established, giving us the service object we can use to
+            // interact with the service.  Because we have bound to a explicit
+            // service that we know is running in our own process, we can
+            // cast its IBinder to a concrete class and directly access it.
+            mBoundService = ((BabbleService2.LocalBinder) service).getService();
+            BabbleServiceBinder.this.onServiceConnected();
+        }
+
+        public void onServiceDisconnected(ComponentName className) {
+            // This is called when the connection with the service has been
+            // unexpectedly disconnected -- that is, its process crashed.
+            // Because it is running in our same process, we should never
+            // see this happen.
+            mBoundService = null;
+            BabbleServiceBinder.this.onServiceDisconnected();
+        }
+    };
+
+    protected void doBindService() {
+        // Attempts to establish a connection with the service.  We use an
+        // explicit class name because we want a specific service
+        // implementation that we know will be running in our own process
+        // (and thus won't be supporting component replacement by other
+        // applications).
+        if (getActivity().bindService(new Intent(getActivity(), BabbleService2.class), mConnection, Context.BIND_AUTO_CREATE)) {
+            mShouldUnbind = true;
+        } else {
+            Log.e("MY_APP_TAG", "Error: The requested service doesn't " +
+                    "exist, or this client isn't allowed access to it.");
+        }
+    }
+
+    protected abstract void onServiceConnected();
+
+    protected abstract void onServiceDisconnected();
+
+    protected void doUnbindService() {
+        if (mShouldUnbind) {
+            // Release information about the service's state.
+            getActivity().unbindService(mConnection);
+            mShouldUnbind = false;
+        }
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleServiceBinderActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleServiceBinderActivity.java
@@ -1,0 +1,99 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.service;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+
+public abstract class BabbleServiceBinderActivity extends AppCompatActivity {
+    // Don't attempt to unbind from the service unless the client has received some
+    // information about the service's state.
+    private boolean mShouldUnbind;
+
+    // To invoke the bound service, first make sure that this value
+    // is not null.
+    protected BabbleService2 mBoundService;
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            // This is called when the connection with the service has been
+            // established, giving us the service object we can use to
+            // interact with the service.  Because we have bound to a explicit
+            // service that we know is running in our own process, we can
+            // cast its IBinder to a concrete class and directly access it.
+            mBoundService = ((BabbleService2.LocalBinder) service).getService();
+            BabbleServiceBinderActivity.this.onServiceConnected();
+        }
+
+        public void onServiceDisconnected(ComponentName className) {
+            // This is called when the connection with the service has been
+            // unexpectedly disconnected -- that is, its process crashed.
+            // Because it is running in our same process, we should never
+            // see this happen.
+            mBoundService = null;
+            BabbleServiceBinderActivity.this.onServiceDisconnected();
+        }
+    };
+
+    protected void doBindService() {
+        // Attempts to establish a connection with the service.  We use an
+        // explicit class name because we want a specific service
+        // implementation that we know will be running in our own process
+        // (and thus won't be supporting component replacement by other
+        // applications).
+        if (bindService(new Intent(this, BabbleService2.class), mConnection, Context.BIND_AUTO_CREATE)) {
+            mShouldUnbind = true;
+        } else {
+            Log.e("MY_APP_TAG", "Error: The requested service doesn't " +
+                    "exist, or this client isn't allowed access to it.");
+        }
+    }
+
+    protected abstract void onServiceConnected();
+
+    protected abstract void onServiceDisconnected();
+
+    void doUnbindService() {
+        if (mShouldUnbind) {
+            // Release information about the service's state.
+            unbindService(mConnection);
+            mShouldUnbind = false;
+        }
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        doUnbindService();
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/ServiceAdvertiser.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/ServiceAdvertiser.java
@@ -1,0 +1,40 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.service;
+
+
+
+public interface ServiceAdvertiser {
+
+    //TODO: swap out the "string methods" with the "list methods"
+
+    //boolean advertise(List<Peer> genesisPeers, List<Peer> currentPeers);
+    boolean advertise(String genesisPeers, String currentPeers);
+
+    void stopAdvertising();
+
+    //void onPeersChange(List<Peer> newPeers);
+    void onPeersChange(String newPeers);
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser2.java
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery.mdns;
+
+import android.content.Context;
+import android.net.nsd.NsdManager;
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import io.mosaicnetworks.babble.discovery.HttpPeerDiscoveryServer;
+import io.mosaicnetworks.babble.discovery.PeersProvider;
+import io.mosaicnetworks.babble.node.GroupDescriptor;
+import io.mosaicnetworks.babble.service.ServiceAdvertiser;
+import io.mosaicnetworks.babble.utils.RandomString;
+
+public class MdnsAdvertiser2 implements ServiceAdvertiser {
+
+    public static final String SERVICE_TYPE = "_babble._tcp.";
+    public static final String APP_IDENTIFIER = "appIdentifier";
+    public static final String GROUP_NAME = "groupName";
+    public static final String GROUP_UID = "groupUid";
+    private static int sDiscoveryPort = 8988;
+    private NsdManager mNsdManager;
+    private NsdManager.RegistrationListener mRegistrationListener;
+    private String mServiceName;
+    private NsdServiceInfo mServiceInfo = new NsdServiceInfo();
+    private Context mAppContext;
+    private HttpPeerDiscoveryServer mHttpPeerDiscoveryServer;
+    private String mCurrentPeers;
+    private boolean mAdvertising = false;
+
+    public MdnsAdvertiser2(GroupDescriptor groupDescriptor, Context context) {
+        initializeRegistrationListener();
+
+        mAppContext = context.getApplicationContext();
+        mServiceInfo.setServiceType(SERVICE_TYPE);
+        mServiceName = new RandomString(32).nextString();
+        mServiceInfo.setServiceName(mServiceName);
+        mServiceInfo.setAttribute(APP_IDENTIFIER, mAppContext.getPackageName());
+        // https://developer.android.com/studio/build/application-id note: The application ID
+        // used to be directly tied to your code's package name; so some Android APIs use the term
+        // "package name" in their method names and parameter names, but this is actually your
+        // application ID. For example, the Context.getPackageName() method
+        // returns your application ID
+        mServiceInfo.setAttribute(GROUP_NAME, groupDescriptor.getName());
+        mServiceInfo.setAttribute(GROUP_UID, groupDescriptor.getUid());
+        mServiceInfo.setPort(sDiscoveryPort);
+    }
+
+    @Override
+    public boolean advertise(final String genesisPeers, final String currentPeers) {
+
+        mCurrentPeers = currentPeers;
+
+        mHttpPeerDiscoveryServer = new HttpPeerDiscoveryServer(sDiscoveryPort, new PeersProvider() {
+            @Override
+            public String getGenesisPeers() {
+                return genesisPeers;
+            }
+
+            @Override
+            public String getCurrentPeers() {
+                return mCurrentPeers;
+            }
+        });
+
+        try {
+            mHttpPeerDiscoveryServer.start();
+            Log.d("MY-TAG", "advertise: Success");
+        } catch (IOException ex) {
+            //Probably the port is in use, we'll continue without the discovery service
+            return false;
+        }
+
+        mNsdManager = (NsdManager) mAppContext.getSystemService(Context.NSD_SERVICE);
+        Objects.requireNonNull(mNsdManager).registerService(mServiceInfo, NsdManager.PROTOCOL_DNS_SD, mRegistrationListener);
+
+        mAdvertising = true;
+
+        //TODO: is it worth this using the success/fail callback of the NSD manager service registration?
+        return true;
+    }
+
+    @Override
+    public void onPeersChange(String newPeers) {
+        mCurrentPeers = newPeers;
+    }
+
+    @Override
+    public void stopAdvertising() {
+
+        if (mAdvertising) {
+            mNsdManager.unregisterService(mRegistrationListener);
+
+            mHttpPeerDiscoveryServer.stop();
+            mHttpPeerDiscoveryServer = null;
+            mAdvertising = false;
+        }
+    }
+
+    private void initializeRegistrationListener() {
+        mRegistrationListener = new NsdManager.RegistrationListener()  {
+
+            @Override
+            public void onServiceRegistered(NsdServiceInfo NsdServiceInfo) {
+                // Save the service name. Android may have changed it in order to
+                // resolve a conflict, so update the name we initially requested
+                // with the name Android actually used - We chose a random string
+                // anyway, so:
+                // 1) It's almost certain to be unique
+                // 2) We don't care if Android changes it
+                mServiceName = NsdServiceInfo.getServiceName();
+            }
+
+            @Override
+            public void onRegistrationFailed(NsdServiceInfo serviceInfo, int errorCode) {}
+
+            @Override
+            public void onServiceUnregistered(NsdServiceInfo arg0) {}
+
+            @Override
+            public void onUnregistrationFailed(NsdServiceInfo serviceInfo, int errorCode) {}
+        };
+    }
+
+    public String getServiceName() {
+        return mServiceName;
+    }
+}
+
+
+
+

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PService2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PService2.java
@@ -1,0 +1,608 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery.p2p;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.content.res.Resources;
+// import android.net.wifi.WifiManager;
+import android.net.wifi.WpsInfo;
+import android.net.wifi.p2p.WifiP2pConfig;
+import android.net.wifi.p2p.WifiP2pDevice;
+import android.net.wifi.p2p.WifiP2pManager;
+import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceInfo;
+import android.net.wifi.p2p.nsd.WifiP2pDnsSdServiceRequest;
+import android.util.Log;
+
+import androidx.core.util.Consumer;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.mosaicnetworks.babble.configure.OnNetworkInitialised;
+import io.mosaicnetworks.babble.service.ServiceAdvertiser;
+import io.mosaicnetworks.babble.servicediscovery.ServiceDiscoveryListener;
+import io.mosaicnetworks.babble.utils.RandomString;
+
+/**
+ * Service class to handle WiFi Direct (P2P)
+ */
+public class P2PService2 implements ServiceAdvertiser {
+
+    private ServiceDiscoveryListener mServiceDiscoveryListener;
+    private OnNetworkInitialised mNetworkInitListener;
+    private P2PConnected mP2PConnected;
+
+    public static Consumer<String> mLogFunc;
+
+
+// If you get errors like this:
+// D/WifiP2pManager: Ignored { when=-4ms what=139313 target=android.net.wifi.p2p.WifiP2pManager$Channel$P2pHandler }
+// The what is defined relative to a BASE as defined in https://android.googlesource.com/platform/frameworks/base.git/+/android-4.3_r2.1/core/java/com/android/internal/util/Protocol.java
+// public static final int BASE_WIFI_P2P_MANAGER = 0x00022000;
+// 0x22000 is 139264, 139313 = BASE + 49
+// In the WifiP2pManager.Channel source file
+// public static final int PING = BASE + 49;
+
+
+
+    // Service type should not need to change, but other values are available at:
+    // http://www.dns-sd.org/ServiceTypes.html
+    private final static String P2P_SERVICE_TYPE = "_presence._tcp";
+//    private final static String P2P_SERVICE_TYPE = "_babble._tcp";
+
+
+    // Keys used for the hash map in DNS text file
+    public final static String HOST_LABEL = "host";
+    public final static String PORT_LABEL = "port";
+    public final static String MONIKER_LABEL = "moniker";
+    public final static String DNS_VERSION_LABEL = "textvers";
+    private final static String DNS_VERSION = "0.0.1";
+    public final static String BABBLE_VERSION_LABEL = "babblevers";
+    public final static String GROUP_ID_LABEL = "groupid";
+    public final static String DEFAULT_IP_ADDRESS = "192.168.49.1";
+    public final static String APP_LABEL = "app";
+    public final static String GROUP_LABEL = "group";
+    final static public int SERVER_PORT = 8988;
+    final static private String TAG = "P2PService2";
+    public static final int RETRY_DELAY_MS = 1000;
+    public static final int RETRY_LIMIT = 4;
+
+    public static boolean mGroupCreated = false;  //TODO: verify this is set to false on exit.
+
+
+
+    private final static String WIFI_DIRECT_IP_PREFIX = "192.168.49.";
+    private static String mMoniker = "Moniker";
+
+    public static boolean getIsDiscovering() {
+        return mIsDiscovering;
+    }
+
+    public static void setIsDiscovering(boolean mIsDiscovering) {
+        P2PService2.mIsDiscovering = mIsDiscovering;
+        Log.i(TAG, "SetIsDiscovering: " + mIsDiscovering);
+    }
+
+    private static boolean mIsDiscovering = false;
+
+    private static P2PService2 INSTANCE;
+    private Context mAppContext;
+    //    private WifiManager mWifiMgr;
+    private WifiP2pManager mWifiP2pMgr;
+    private WifiP2pManager.Channel mChannel;
+    public BroadcastReceiver mReceiver;
+    public IntentFilter mIntentFilter;
+
+    private final Map<String, P2PResolvedService> mResolvedServices = new HashMap<>();
+    private List<P2PResolvedGroup> mResolvedGroups;  //TODO: Look to make this final
+//    final HashMap<String, Map> textRecords = new HashMap<>();
+
+    private String mServiceName ;
+
+
+    /**
+     * Factory for the {@link P2PService2}
+     *
+     * @return a messaging service
+     */
+    public static P2PService2 getInstance(Context context) {
+        if (INSTANCE == null) {
+            INSTANCE = new P2PService2(context.getApplicationContext());
+        }
+        return INSTANCE;
+    }
+
+
+    private P2PService2(Context context) {
+        mAppContext = context;
+        Log.i(TAG,"Constructed");
+        initP2P();
+    }
+
+
+    public void registerOnNetworkInitialised(OnNetworkInitialised listener) {
+        this.mNetworkInitListener = listener;
+    }
+
+
+    public void registerP2PConnected(P2PConnected listener) {
+        this.mP2PConnected = listener;
+    }
+
+
+
+    public void registerServiceDiscoveryListener(ServiceDiscoveryListener listener){
+        this.mServiceDiscoveryListener  =listener;
+    }
+
+
+    public void setResolvedGroups(List<P2PResolvedGroup> resolvedGroups) {
+        this.mResolvedGroups = resolvedGroups;
+    }
+
+    protected void initP2P(){
+        // mWifiMgr = (WifiManager) mAppContext.getSystemService(Context.WIFI_SERVICE);
+        //       mWifiMgr.setWifiEnabled(false);
+        // This is deprecated in API 29 and on. 3rd party apps may no longer turn WiFi on or off.
+        //TODO: Remove all the mWifiMgr code which has been commented out for now.
+
+        mWifiP2pMgr = (WifiP2pManager) mAppContext.getApplicationContext().getSystemService(Context.WIFI_P2P_SERVICE);
+        Log.i(TAG, "Got manager" );
+
+        mChannel = mWifiP2pMgr.initialize(mAppContext, mAppContext.getMainLooper(), null);
+        Log.i(TAG, "Initialised manager" );
+
+        mReceiver = new WifiDirectBroadcastReceiver(mWifiP2pMgr, mChannel, mAppContext);
+        Log.i(TAG, "Created Receiver" );
+
+        mIntentFilter = new IntentFilter();
+        mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_STATE_CHANGED_ACTION);
+        mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_PEERS_CHANGED_ACTION);
+        mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_CONNECTION_CHANGED_ACTION);
+        mIntentFilter.addAction(WifiP2pManager.WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
+        Log.i(TAG, "Added intent actions" );
+
+
+
+    }
+
+
+    public void stopRegistration(){
+
+    }
+
+
+    public void startRegistration(String moniker, String groupName, String babbleVersion, boolean startDiscoverService) {
+        //  Create a string map containing information about your service.
+
+        Log.i(TAG, "startRegistration()");
+        HashMap<String,String> record = new HashMap<String,String>();
+
+        mServiceName = new RandomString(32).nextString();
+        record.put(GROUP_LABEL, groupName);
+        record.put(GROUP_ID_LABEL, mServiceName);
+        // This is a bit chicken and egg.
+        // But we know what the address of the leader will be, so it is safe to do this.
+        record.put(HOST_LABEL, DEFAULT_IP_ADDRESS);
+        record.put(PORT_LABEL, String.valueOf(SERVER_PORT));
+        record.put(APP_LABEL, mAppContext.getPackageName());
+        record.put(MONIKER_LABEL, moniker); // "John Doe" + (int) (Math.random() * 1000));
+        record.put(DNS_VERSION_LABEL, DNS_VERSION);
+        record.put(BABBLE_VERSION_LABEL, babbleVersion);
+
+        // Service information.  Pass it an instance name, service type
+        // _protocol._transportlayer , and the map containing
+        // information other devices will want once they connect to this one.
+//        WifiP2pDnsSdServiceInfo serviceInfo =
+        //              WifiP2pDnsSdServiceInfo.newInstance(mServiceName, P2P_SERVICE_TYPE, record);
+
+        WifiP2pDnsSdServiceInfo serviceInfo =
+                WifiP2pDnsSdServiceInfo.newInstance("_Babble", P2P_SERVICE_TYPE, record);
+
+        // Add the local service, sending the service info, network channel,
+        // and listener that will be used to indicate success or failure of
+        // the request.
+        mWifiP2pMgr.addLocalService(mChannel, serviceInfo, new WifiP2pManager.ActionListener() {
+            @Override
+            public void onSuccess() {
+                // Command successful! Code isn't necessarily needed here,
+                // Unless you want to update the UI or add logging statements.
+                Log.i(TAG,"Added local service");
+                mGroupCreated = false;
+                createGroup(0);
+                //       onInitialiseNetworkCallback();   //TODO: JK - Review and remove
+            }
+
+            @Override
+            public void onFailure(int arg0) {
+                // Command failed.  Check for P2P_UNSUPPORTED, ERROR, or BUSY
+                Log.i(TAG,"Failed to add local service");
+            }
+        });
+
+        if (startDiscoverService) {
+            discoverService();
+        }
+    }
+
+    public void onInitialiseNetworkCallback() {
+        if (this.mNetworkInitListener != null) {
+            String ip = getLocalIPAddress();
+            Log.i(TAG,"IP" + ip);
+
+            // This is a strange one. Some devices do initialise their group quite happily.
+            // And some don't. This checks to see if the IP is set, and calls the fallback
+            // createGroup code if not.
+            //TODO: JK prevent infinite loop here. CreateGroup will call this function. If it succeeds
+            //      whilst failing to set the IP we have an infinite loop.
+            if ( (ip == null) ) { // || (!mGroupCreated )) {
+                Log.i(TAG,"Null IP - Pausing");
+
+
+
+
+                new android.os.Handler().postDelayed(
+                        new Runnable() {
+                            public void run() {
+                                Log.i(TAG,"Retry onInitialiseNetworkCallback");
+                                onInitialiseNetworkCallback();
+                            }
+                        },
+                        RETRY_DELAY_MS);
+
+                return;
+            }
+
+            mNetworkInitListener.onNetworkInitialised(ip);
+        }
+
+    }
+
+
+    public void createGroup(final int count) {
+
+        Log.i(TAG,"createGroup");
+        if (mGroupCreated) {
+            return ; // onInitialiseNetworkCallback();
+        }
+
+        mWifiP2pMgr.createGroup(mChannel, new WifiP2pManager.ActionListener() {
+            @Override
+            public void onSuccess() {
+                Log.i(TAG, "P2PAdvertise: Successfully created group");
+                mGroupCreated = true;
+                onInitialiseNetworkCallback();
+            }
+
+            @Override
+            public void onFailure(int arg0) {
+
+                String errType = "Unknown error";
+
+                switch (arg0) {
+                    case   WifiP2pManager.P2P_UNSUPPORTED:
+                        errType = "Unsupported";
+                        break;
+
+                    case WifiP2pManager.ERROR:
+                        errType = "Error";
+                        break;
+
+                    case WifiP2pManager.BUSY:
+                        errType = "Busy";
+                        break;
+                }
+
+                Log.e(TAG, "P2PAdvertise: Error creating group: " + errType + "("+arg0+")");
+
+
+                if ( ( arg0 == WifiP2pManager.BUSY )  && (! mGroupCreated ) ){
+
+                    if (count > RETRY_LIMIT) {
+                        //TODO: error handle
+                        onInitialiseNetworkCallback();
+                        return;
+                    }
+
+                    new android.os.Handler().postDelayed(
+                            new Runnable() {
+                                public void run() {
+                                    Log.i(TAG,"Retry createGroup");
+                                    createGroup(count+1);
+                                }
+                            },
+                            RETRY_DELAY_MS);
+                }
+
+
+            }
+        });
+
+    }
+
+
+
+
+    public void stopDiscoverService() {
+
+        //TODO: Actually stop discovery. Not a serious issue, it times out anyway
+        /*
+            Service discovery will only last for 120 seconds from the time the discoverServices
+            method of WifiP2pManager is called. If application developers require service discovery
+            for a longer period, they will need to re-call the WifiP2pManager.discoverServices method.
+         */
+        setIsDiscovering(false);
+        mGroupCreated = false;
+
+    }
+
+    public void discoverService() {
+        Log.i(TAG, "discoverService()");
+        WifiP2pManager.DnsSdTxtRecordListener txtListener = new WifiP2pManager.DnsSdTxtRecordListener() {
+
+            public void onDnsSdTxtRecordAvailable(
+                    String fullDomain, Map record, WifiP2pDevice device) {
+                Log.i(TAG, "DnsSdTxtRecord available -" + record.toString());
+
+                String groupId = device.deviceAddress;
+
+
+                //TODO: Restore this deduplicating code. Or at least stop it suppressing all entries.
+           /*
+                if (mResolvedServices.containsKey(groupId)) {
+                    //we already have this service
+                    Log.i(TAG, "We already have this service " + groupId);
+                    //TODO: remove this hacky way to force screen update
+                    mServiceDiscoveryListener.onServiceListUpdated(true);
+                    return;
+                };
+*/
+                try {
+                    P2PResolvedService resolvedService = new P2PResolvedService(groupId, record);
+
+
+                    if (!resolvedService.getAppIdentifier().equals(mAppContext.getPackageName())) {
+                        //The service is not for this app, we'll skip it
+                        return;  //TODO: this may need to be modified if multiple apps share babble
+                    }
+                    P2PResolvedGroup resolvedGroup = new P2PResolvedGroup(resolvedService);
+                    mResolvedGroups.add(resolvedGroup);
+                    resolvedService.setResolvedGroup(resolvedGroup);
+                    mResolvedServices.put(groupId, resolvedService);
+                    mServiceDiscoveryListener.onServiceListUpdated(true);
+
+                } catch (UnknownHostException ex) {
+
+                    Log.i(TAG,ex.getMessage());  //TODO: Implement proper error handling
+
+                    return;
+                }
+
+            }
+        };
+
+        WifiP2pManager.DnsSdServiceResponseListener servListener = new WifiP2pManager.DnsSdServiceResponseListener() {
+            @Override
+            public void onDnsSdServiceAvailable(String instanceName, String registrationType,
+                                                WifiP2pDevice resourceType) {
+
+                // We always set a TXT file, so in a correctly functioning environment,
+                // the TXT file should always be available.
+                Log.i(TAG,"Found " + instanceName + " " + registrationType);
+
+            }
+        };
+
+        mWifiP2pMgr.setDnsSdResponseListeners(mChannel, servListener, txtListener);
+
+        WifiP2pDnsSdServiceRequest serviceRequest = WifiP2pDnsSdServiceRequest.newInstance();
+        mWifiP2pMgr.addServiceRequest(mChannel,
+                serviceRequest,
+                new WifiP2pManager.ActionListener() {
+                    @Override
+                    public void onSuccess() {
+                        // Success!
+                        Log.i(TAG,"mWifiP2pMgr.addServiceRequest success");
+                    }
+
+                    @Override
+                    public void onFailure(int code) {
+                        // Command failed.  Check for P2P_UNSUPPORTED, ERROR, or BUSY
+
+                        Log.i(TAG,"mWifiP2pMgr.addServiceRequest fail ("+Integer.toString(code));
+                        if (mServiceDiscoveryListener != null) {
+                            mServiceDiscoveryListener.onStartDiscoveryFailed();
+                        }
+                    }
+                });
+
+
+        mWifiP2pMgr.discoverServices(mChannel, new WifiP2pManager.ActionListener() {
+
+            @Override
+            public void onSuccess() {
+                // Success!
+                Log.i(TAG,"mWifiP2pMgr.discoverServices success");
+                setIsDiscovering(true);
+            }
+
+            @Override
+            public void onFailure(int code) {
+                // Command failed.  Check for P2P_UNSUPPORTED, ERROR, or BUSY
+                if (code == WifiP2pManager.P2P_UNSUPPORTED) {
+                    Log.i(TAG, "P2P isn't supported on this device.");
+                } else {
+                    Log.i(TAG, "P2P error. " + Integer.toString(code));
+                }
+
+                if (mServiceDiscoveryListener != null) {
+                    mServiceDiscoveryListener.onStartDiscoveryFailed();
+                }
+
+            }
+        });
+
+    }
+
+
+    public void connectToPeer(String deviceAddress, final String peerIP, final int peerPort) {
+
+        Log.i(TAG,"P2PService2.connectToPeer: "+ deviceAddress);
+
+        if (mResolvedServices.containsKey(deviceAddress)) {
+            P2PResolvedService prs = mResolvedServices.get(deviceAddress);
+
+            WifiP2pConfig config = new WifiP2pConfig();
+            config.deviceAddress = deviceAddress;
+            config.wps.setup = WpsInfo.PBC;
+            config.groupOwnerIntent = 0; //TODO: WifiP2pConfig.GROUP_OWNER_INTENT_MIN for API >= 30
+            mWifiP2pMgr.connect(mChannel, config,new WifiP2pManager.ActionListener() {
+
+                @Override
+                public void onSuccess() {
+
+                    Log.i(TAG,"mWifiP2pMgr.connect succeeded.");
+
+
+                    getClientIP(peerIP, peerPort, 0);
+
+                }
+
+                @Override
+                public void onFailure(int reason) {
+                    Log.i(TAG,"mWifiP2pMgr.connect failed. Retry.");
+                }
+            });
+
+        } else {
+            throw new Resources.NotFoundException("Selected Peer not discovered");
+        }
+
+    }
+
+
+    private void getClientIP(final String peerIP, final int peerPort, final int count) {
+
+        Log.i(TAG,"getClientIP");
+
+        String ip = getLocalIPAddress();
+        Log.i(TAG,"IP: " + ip);
+
+        if (  ( (ip == null) || (ip.equals(DEFAULT_IP_ADDRESS)) ) && ( count < RETRY_LIMIT )) {
+
+            new android.os.Handler().postDelayed(
+                    new Runnable() {
+                        public void run() {
+                            Log.i(TAG,"Retry getClientIP");
+                            getClientIP(peerIP, peerPort, count+1);
+                        }
+                    },
+                    RETRY_DELAY_MS);
+            return;
+        }
+
+
+        //Callback
+        if ( mP2PConnected != null) {
+            mP2PConnected.onConnected(peerIP, peerPort);
+        }
+
+    }
+
+
+
+    private String getLocalIPAddress() {
+        try {
+
+
+            for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
+                NetworkInterface intf = en.nextElement();
+                String interfaceName = intf.getDisplayName();
+                Log.i(TAG,"Interface: " + interfaceName);
+                for (Enumeration<InetAddress> enumIpAddr = intf.getInetAddresses(); enumIpAddr.hasMoreElements();) {
+                    InetAddress inetAddress = enumIpAddr.nextElement();
+                    String ipStr = getDottedDecimalIP(inetAddress.getAddress());
+                    Log.i(TAG,"IP: "+ipStr);
+                    if (!inetAddress.isLoopbackAddress()) {
+                        if (inetAddress instanceof Inet4Address) {
+                            if (ipStr.startsWith(WIFI_DIRECT_IP_PREFIX)) {
+                                Log.i(TAG,"Using interface: " + interfaceName);
+                                Log.i(TAG,"Using address: " + ipStr);
+                                return ipStr;
+                            }
+                        }
+
+                    }
+                }
+            }
+
+        } catch (SocketException ex) {
+            //Log.e("AndroidNetworkAddressFactory", "getLocalIPAddress()", ex);
+        } catch (NullPointerException ex) {
+            //Log.e("AndroidNetworkAddressFactory", "getLocalIPAddress()", ex);
+        }
+        return null;
+    }
+
+    private String getDottedDecimalIP(byte[] ipAddr) {
+        //convert to dotted decimal notation:
+        String ipAddrStr = "";
+        for (int i=0; i<ipAddr.length; i++) {
+            if (i > 0) {
+                ipAddrStr += ".";
+            }
+            ipAddrStr += ipAddr[i]&0xFF;
+        }
+        return ipAddrStr;
+    }
+
+    @Override
+    public boolean advertise(String genesisPeers, String currentPeers) {
+        // Do nothing. It is implicit in the starting a Wifi Direct node
+        Log.i(TAG,"P2P advertise, does nothing");
+        return true;
+    }
+
+    @Override
+    public void stopAdvertising() {
+        // Do nothing. It is implicit in the starting a Wifi Direct node
+        mGroupCreated = false;
+        Log.i(TAG,"P2P stop advertise, does nothing");
+    }
+
+    @Override
+    public void onPeersChange(String newPeers) {
+        //do nothing
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/utils/DialogUtils.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/utils/DialogUtils.java
@@ -25,6 +25,7 @@
 package io.mosaicnetworks.babble.utils;
 
 import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.webkit.WebView;
 
@@ -65,13 +66,25 @@ public class DialogUtils {
 
         String fullhtml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
                 "<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></head><body>\n" +
-                html + "\n</body>\n</html>" ;
+                html + "\n</body>\n</html>";
 
         WebView view = new WebView(context);
         view.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
         view.setPadding(10, 10, 10, 10);
         dialog.setView(view);
         dialog.show();
+    }
+
+    public static ProgressDialog displayLoadingDialog(Context context) {
+        ProgressDialog loadingDialog = new ProgressDialog(context);
+        loadingDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+        loadingDialog.setTitle("Loading chat");
+        loadingDialog.setMessage("Loading. Please wait...");
+        loadingDialog.setIndeterminate(true);
+        loadingDialog.setCanceledOnTouchOutside(false);
+
+        return loadingDialog;
+
     }
 
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.mosaicnetworks.sample">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -33,7 +35,15 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ChatActivity" />
+
+        <service
+            android:name="io.mosaicnetworks.babble.service.BabbleService2"
+            android:enabled="true"
+            android:stopWithTask="true"
+            android:exported="false" />
+
+        <activity android:name=".ChatActivityAndroidService" />
+        <activity android:name=".ChatActivityAndroidService" />
         <activity android:name=".MainActivity"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivityAndroidService.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivityAndroidService.java
@@ -1,0 +1,208 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.sample;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.squareup.picasso.Picasso;
+import com.stfalcon.chatkit.commons.ImageLoader;
+import com.stfalcon.chatkit.messages.MessageInput;
+import com.stfalcon.chatkit.messages.MessagesList;
+import com.stfalcon.chatkit.messages.MessagesListAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.mosaicnetworks.babble.node.ServiceObserver;
+import io.mosaicnetworks.babble.service.BabbleServiceBinderActivity;
+
+/**
+ * This is the central UI component. It receives messages from the {@link MessagingService} and
+ * displays them as a list.
+ */
+public class ChatActivityAndroidService extends BabbleServiceBinderActivity implements ServiceObserver {
+
+    private MessagesListAdapter<Message> mAdapter;
+    private String mMoniker;
+    private Integer mMessageIndex = 0;
+    private boolean mArchiveMode;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chat);
+
+        Log.i("ChatActivity", "onCreate");
+
+        Intent intent = getIntent();
+        mMoniker = intent.getStringExtra("MONIKER");
+        mArchiveMode = intent.getBooleanExtra("ARCHIVE_MODE", false);
+
+        initialiseAdapter();
+        doBindService();
+
+
+    }
+
+    @Override
+    protected void onServiceConnected() {
+
+        mBoundService.registerObserver(this);
+
+        Log.i("ChatActivity", "registerObserver");
+
+
+        if (mArchiveMode) {
+            stateUpdated();
+
+            if (mMessageIndex==0) {
+                findViewById(R.id.relativeLayout_messages).setVisibility(View.GONE);
+                findViewById(R.id.linearLayout_empty_archive).setVisibility(View.VISIBLE);
+            }
+
+        } else {
+            /*
+            if ((!mBoundService.isAdvertising()) && (!mArchiveMode )) {
+                Toast.makeText(this, "Unable to advertise peers", Toast.LENGTH_LONG).show();
+            }
+
+             */
+        }
+
+
+    }
+
+    @Override
+    protected void onServiceDisconnected() {
+
+    }
+
+    private void initialiseAdapter() {
+        MessagesList mMessagesList = findViewById(R.id.messagesList);
+
+        mAdapter = new MessagesListAdapter<>(mMoniker,   new ImageLoader() {
+            @Override
+            public void loadImage(ImageView imageView, String url, Object payload) {
+                // If string URL starts with R. it is a resource.
+                if (url.startsWith("R.")) {
+                    String[] arrUrl = url.split("\\.", 3);
+                    int ResID = getResources().getIdentifier(arrUrl[2] , arrUrl[1], ChatActivityAndroidService.this.getPackageName());
+                    Log.i("ChatActivity", "loadImage: " +ResID + " "+ arrUrl[2] + " "+ arrUrl[1] + " "+ ChatActivityAndroidService.this.getPackageName());
+                    if (ResID == 0) {
+                        Picasso.get().load(R.drawable.error).into(imageView);
+                    } else {
+                        Picasso.get().load(ResID).into(imageView);  //TODO restore this line
+                    }
+                } else {
+                    Picasso.get().load(url).into(imageView);
+                }
+            }
+        });
+
+        mMessagesList.setAdapter(mAdapter);
+
+        MessageInput input = findViewById(R.id.input);
+        if (mArchiveMode) {
+            input.setVisibility(View.GONE);
+        } else {
+            input.setInputListener(new MessageInput.InputListener() {
+                @Override
+                public boolean onSubmit(CharSequence input) {
+                    mBoundService.submitTx(new Message(input.toString(), mMoniker));
+                    return true;
+                }
+            });
+        }
+    }
+
+    /**
+     * Called after the {@link MessagingService} state is updated. This happens after transactions
+     * received from the babble node are applied to the state. At this point the
+     * {@link ChatActivityAndroidService} retrieves all messages with index greater than it's current index.
+     */
+    @Override
+    public void stateUpdated() {
+
+        if (mMessageIndex==0) {
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    findViewById(R.id.relativeLayout_messages).setVisibility(View.VISIBLE);
+                    findViewById(R.id.linearLayout_empty_archive).setVisibility(View.GONE);
+                }
+            });
+        }
+
+        List<Message> newMessagesTemp = new ArrayList<>();
+
+        for (Message m : ((ChatState) mBoundService.getAppState()).getMessagesFromIndex(mMessageIndex)) {
+
+            if (m.author.equals(mMoniker)) {
+                newMessagesTemp.add(m);
+            } else {
+                if (m.author.equals(Message.SYSTEM_MESSAGE_AUTHOR)) {
+                    newMessagesTemp.add(m);
+                } else {
+                    newMessagesTemp.add(new Message(m.author+ ":\n" + m.text, m.author, m.date));
+                }
+            }
+
+        }
+
+        final List<Message> newMessages = newMessagesTemp;
+
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                for (Message message : newMessages ) {
+                    mAdapter.addToStart(message, true);
+                }
+            }
+        });
+
+        mMessageIndex = mMessageIndex + newMessages.size();
+    }
+
+    /**
+     * When back is pressed we should leave the group. The {@link #onDestroy()} method will handle
+     * unregistering from the service
+     */
+    @Override
+    public void onBackPressed() {
+        mBoundService.leave(null);
+        super.onBackPressed();
+    }
+
+    @Override
+    public void onDestroy() {
+        mBoundService.removeObserver(this);
+
+        super.onDestroy();
+    }
+}

--- a/sample/src/main/java/io/mosaicnetworks/sample/MainActivity.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/MainActivity.java
@@ -30,12 +30,13 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import java.util.Objects;
-
 import io.mosaicnetworks.babble.configure.BaseConfigActivity;
 import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.utils.DialogUtils;
 import io.mosaicnetworks.babble.utils.Utils;
+
+import io.mosaicnetworks.babble.service.BabbleService2;
+
 
 public class MainActivity extends BaseConfigActivity {
 
@@ -48,6 +49,8 @@ public class MainActivity extends BaseConfigActivity {
 
         // Show all versions of each group in the archive tab
         setShowAllArchiveVersions(true);
+
+        BabbleService2.setAppState(new ChatState());
 
         super.onCreate(savedInstanceState);
 
@@ -84,22 +87,20 @@ public class MainActivity extends BaseConfigActivity {
 
     @Override
     public void onStartedNew(String moniker, String group) {
-        Intent intent = new Intent(this, ChatActivity.class);
+        Intent intent = new Intent(this, ChatActivityAndroidService.class);
         intent.putExtra("MONIKER", moniker);
         intent.putExtra("ARCHIVE_MODE", false);
         intent.putExtra("GROUP", group);
         startActivity(intent);
     }
 
-    @Override
     public void onArchiveLoaded(String moniker, String group) {
-        Intent intent = new Intent(this, ChatActivity.class);
+        Intent intent = new Intent(this, ChatActivityAndroidService.class);
         intent.putExtra("MONIKER", moniker);
         intent.putExtra("ARCHIVE_MODE", true);
         intent.putExtra("GROUP", group);
         startActivity(intent);
     }
-
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -134,15 +135,19 @@ public class MainActivity extends BaseConfigActivity {
                 +prelabel+ "Version Name"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.VERSION_NAME+ postdata
                 +prelabel+ "Git Hash"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.GitHash+ postdata
                 +prelabel+ "Git Hash Short"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.GitHashShort+ postdata
-                +prelabel+ "Git Branch"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.GitBranch +postdata+postBlock
-                +"\n<hr>\n"
+                +prelabel+ "Git Branch"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.GitBranch +postdata
+                +postBlock
+                +"<hr>\n"
+                +preBlock
+                +prelabel+ "Babble Version"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.BabbleVersion +postdata
+                +prelabel+ "Babble Repo"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.BabbleRepo +postdata
+                +prelabel+ "Babble Method"+postlabel+predata+ io.mosaicnetworks.babble.BuildConfig.BabbleMethod +postdata
+
+                +postBlock+"\n<hr>\n"
                 +preBlock
                 +prelabel+"IP Address"+postlabel+predata+ Utils.getIPAddr(this)+postdata
                 +postBlock + "\n<hr>\n";
 
         DialogUtils.displayOkAlertDialogHTML(this, R.string.about_title, aboutText);
     }
-
-
-
 }

--- a/sample/src/main/res/layout/activity_chat.xml
+++ b/sample/src/main/res/layout/activity_chat.xml
@@ -121,7 +121,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white"
-        tools:context=".ChatActivity">
+        tools:context=".ChatActivityAndroidService">
 
         <com.stfalcon.chatkit.messages.MessagesList
             android:id="@+id/messagesList"


### PR DESCRIPTION
Add an Android Service, BabbleService2, which replicates much of the
functionality of the BabbleService singleton class. For creating a new
group and opening an archive, the new BabbleService2 is used. For
joining a group the original BabbleService is used. Within the sample
app creating a new group or opening an archive uses a new ChatActivity2.
The intention is to remove BabbleService and ChatActivity once the
discovery process has been refactored.