### PR TITLE
Stop chat if Node suspends

### DIFF
--- a/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleNode.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleNode.java
@@ -87,7 +87,8 @@ public final class BabbleNode implements PeersProvider {
 
     private final Node mNode;
 
-    public static BabbleNode create(final BlockConsumer blockConsumer, String configDir) {
+    public static BabbleNode create(final BlockConsumer blockConsumer, String configDir,
+                                    final NodeStateChangeHandler stateChangeHandler) {
 
         Log.i("BabbleNode.create", configDir);
         Node node = Mobile.new_(
@@ -113,7 +114,9 @@ public final class BabbleNode implements PeersProvider {
                 new mobile.StateChangeHandler() {
                     @Override
                     public void onStateChanged(final int state) {
-                        System.out.println("BabbleState " + State.fromValue(state));
+                        if (stateChangeHandler!=null) {
+                            stateChangeHandler.onStateChanged(State.fromValue(state));
+                        }
                     }
                 },
                 new mobile.ExceptionHandler() {

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
@@ -131,7 +131,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
                 notifyObservers();
                 return processedBlock;
             }
-        }, configDirectory);
+        }, configDirectory, null);
 
         this.mNetworkType = networkType;
         this.mIsArchive = (this.mNetworkType == 0) ;
@@ -175,7 +175,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
                             notifyObservers();
                             return processedBlock;
                         }
-                    }, configDirectory);
+                    }, configDirectory, null);
 
                 } catch (IllegalArgumentException ex) {
                     //TODO: need more refined Babble exceptions

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/NodeStateChangeHandler.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/NodeStateChangeHandler.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.node;
+
+public interface NodeStateChangeHandler {
+
+    void onStateChanged(BabbleNode.State state);
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/ServiceObserver2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/ServiceObserver2.java
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.service;
+
+import io.mosaicnetworks.babble.node.BabbleNode;
+
+public interface ServiceObserver2 {
+
+    /**
+     * Called when transactions are received and the app state is updated
+     */
+    void stateUpdated();
+
+    void onNodeStateChanged(BabbleNode.State state);
+}

--- a/sample/src/main/java/io/mosaicnetworks/sample/ChatActivityAndroidService.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/ChatActivityAndroidService.java
@@ -24,29 +24,42 @@
 
 package io.mosaicnetworks.sample;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.squareup.picasso.Picasso;
 import com.stfalcon.chatkit.commons.ImageLoader;
 import com.stfalcon.chatkit.messages.MessageInput;
 import com.stfalcon.chatkit.messages.MessagesList;
 import com.stfalcon.chatkit.messages.MessagesListAdapter;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
-import io.mosaicnetworks.babble.node.ServiceObserver;
+import io.mosaicnetworks.babble.discovery.Peer;
+import io.mosaicnetworks.babble.node.BabbleNode;
 import io.mosaicnetworks.babble.service.BabbleServiceBinderActivity;
+import io.mosaicnetworks.babble.service.ServiceObserver2;
+import io.mosaicnetworks.babble.utils.DialogUtils;
+import io.mosaicnetworks.babble.utils.Utils;
 
 /**
  * This is the central UI component. It receives messages from the {@link MessagingService} and
  * displays them as a list.
  */
-public class ChatActivityAndroidService extends BabbleServiceBinderActivity implements ServiceObserver {
+public class ChatActivityAndroidService extends BabbleServiceBinderActivity implements ServiceObserver2 {
 
     private MessagesListAdapter<Message> mAdapter;
     private String mMoniker;
@@ -187,6 +200,92 @@ public class ChatActivityAndroidService extends BabbleServiceBinderActivity impl
         });
 
         mMessageIndex = mMessageIndex + newMessages.size();
+    }
+
+    @Override
+    public void onNodeStateChanged(BabbleNode.State state) {
+
+        if (state== BabbleNode.State.Suspended) {
+            DialogUtils.displayOkAlertDialog(this, R.string.node_suspended_title, R.string.node_suspended_message);
+            MessageInput input = findViewById(R.id.input);
+            input.setVisibility(View.GONE);
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_chat2, menu);
+        return true;
+    }
+
+
+    public void showChatters(MenuItem menuItem) {
+        Gson gson = new Gson();
+        Peer[] peers = gson.fromJson(mBoundService.getMonikerList(), Peer[].class);
+
+        String join = "";
+        String peerList = this.getResources().getString(R.string.monikers_preamble);
+
+        for (int i=0; i< peers.length; i++ ) {
+            peerList = peerList + join + peers[i].moniker;
+            join = ",\n";
+        }
+
+        DialogUtils.displayOkAlertDialogText(this,R.string.monikers_title,peerList) ;
+
+    }
+
+
+
+    public void showIP(MenuItem menuItem) {
+        Context context = getApplicationContext();
+        String ip = "Your IP is: "+ Utils.getIPAddr(context);
+
+        DialogUtils.displayOkAlertDialogText(this,R.string.ip_title,ip) ;
+
+    }
+
+
+    public void showStats(MenuItem menuItem) {
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Map map = gson.fromJson(mBoundService.getStats(), Map.class);
+
+        if (map.containsKey("time"))  // Convert Unix nano seconds to a real date time
+        {
+            String timeStr = (String) map.get("time");
+            Date currentTime = new Date(Long.parseLong(timeStr)  / 1000000L);
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+            String dateString = formatter.format(currentTime);
+            map.put("time", dateString);
+        }
+
+
+
+        boolean plainText = false;
+        if (plainText) {
+            String rawStats = gson.toJson(map);
+
+            String stats = rawStats.replace('{', '\0')
+                    .replace('}', '\0')
+                    .replace('"', '\0')
+                    .replace(',', '\0');
+
+            DialogUtils.displayOkAlertDialogText(this, R.string.stats_title, stats);
+        } else {
+            Iterator<Map.Entry<String, String>> itr = map.entrySet().iterator();
+            String html = "<table>\n";
+
+            while(itr.hasNext()) {
+                Map.Entry<String, String> entry = itr.next();
+                html = html + "<tr><td><font color=\"#0000ff\">" + entry.getKey() + "</font></td><td><font color=\"#ff0000\"> " + entry.getValue() + "</font></td></tr>\n";
+            }
+
+            html = html + "</table>\n";
+
+            DialogUtils.displayOkAlertDialogHTML(this, R.string.stats_title, html);
+        }
     }
 
     /**

--- a/sample/src/main/res/menu/menu_chat2.xml
+++ b/sample/src/main/res/menu/menu_chat2.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ MIT License
   ~
@@ -22,20 +23,31 @@
   ~ SOFTWARE.
   -->
 
-<resources>
-    <string name="app_name">Babble Chat</string>
-    <string name="hint_enter_a_message">Enter a message</string>
-    <string name="no_messages_in_archive">This archive is empty</string>
-    <string name="stats_title">Stats</string>
-    <string name="ip_title">IP Address</string>
-    <string name="monikers_title">Participants</string>
-    <string name="toggle_poll_stats">Toggle Poll Stats</string>
-    <string name="monikers_preamble">"Participants in this Group: \n\n"</string>
-    <string name="poll_stats_state_label">"State: "</string>
-    <string name="poll_stats_trans_label">"Trans: "</string>
-    <string name="poll_stats_events_label">"Events: "</string>
-    <string name="poll_stats_undetermined_label">"Undetermined: "</string>
-    <string name="about_title">About</string>
-    <string name="node_suspended_title">Chat Suspended</string>
-    <string name="node_suspended_message">The number of active participants is too low to achieve consensus.</string>
-</resources>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <item
+        android:id="@+id/iconHamburger"
+        android:icon="@drawable/hamburger"
+        app:showAsAction="ifRoom|withText">
+        <menu>
+            <item
+                android:icon="@drawable/chatters"
+                android:id="@+id/menuItemShowChatters"
+                android:onClick="showChatters"
+                android:title="@string/monikers_title"></item>
+            <item
+                android:icon="@drawable/ip"
+                android:id="@+id/menuItemShowIP"
+                android:onClick="showIP"
+                android:title="@string/ip_title"></item>
+            <item
+                android:icon="@drawable/stats"
+                android:id="@+id/menuItemShowStats"
+                android:onClick="showStats"
+                android:title="@string/stats_title"></item>
+
+        </menu>
+    </item>
+</menu>


### PR DESCRIPTION
Expose BabbleNode state in BabbleService2 using the Node's state change
callback. Service observers are notified of changes to the Node state.
The sample app uses this to notify the user when there are insufficient
active participants to reach consensus.