### PR TITLE
Constants

### DIFF
--- a/babble/src/androidTest/java/io/mosaicnetworks/babble/discovery/HttpPeerDiscoveryRequestTest.java
+++ b/babble/src/androidTest/java/io/mosaicnetworks/babble/discovery/HttpPeerDiscoveryRequestTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import fi.iki.elonen.NanoHTTPD;
+import io.mosaicnetworks.babble.node.BabbleConstants;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -46,13 +47,13 @@ public class HttpPeerDiscoveryRequestTest {
         }
 
         MockHttpPeerDiscoveryServer mockHttpPeerDiscoveryServer = new MockHttpPeerDiscoveryServer(
-                "localhost", 8988, new PeersGet(), 0);
+                "localhost", BabbleConstants.DISCOVERY_PORT(), new PeersGet(), 0);
         mockHttpPeerDiscoveryServer.start();
 
         String host = "localhost";
 
         HttpPeerDiscoveryRequest httpPeerDiscoveryRequest =
-                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, 8988, new ResponseListener() {
+                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, BabbleConstants.DISCOVERY_PORT(), new ResponseListener() {
             @Override
             public void onReceivePeers(List<Peer> peers) {
                 mRcvPeers = peers;
@@ -89,7 +90,7 @@ public class HttpPeerDiscoveryRequestTest {
         String host = "198.51.100.255"; // should be an unreachable ip address
 
         HttpPeerDiscoveryRequest httpPeerDiscoveryRequest =
-                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, 8988, new ResponseListener() {
+                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, BabbleConstants.DISCOVERY_PORT(), new ResponseListener() {
             @Override
             public void onReceivePeers(List<Peer> peers) {
             }

--- a/babble/src/androidTest/java/io/mosaicnetworks/babble/discovery/HttpPeerDiscoveryTest.java
+++ b/babble/src/androidTest/java/io/mosaicnetworks/babble/discovery/HttpPeerDiscoveryTest.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.mosaicnetworks.babble.node.BabbleConstants;
+
 import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
@@ -46,13 +48,13 @@ public class HttpPeerDiscoveryTest {
             }
         }
 
-        HttpPeerDiscoveryServer httpPeerDiscoveryServer = new HttpPeerDiscoveryServer("localhost", 8988, new MockPeersProvider());
+        HttpPeerDiscoveryServer httpPeerDiscoveryServer = new HttpPeerDiscoveryServer("localhost", BabbleConstants.DISCOVERY_PORT(), new MockPeersProvider());
         httpPeerDiscoveryServer.start();
 
         String host = "localhost";
 
         HttpPeerDiscoveryRequest httpPeerDiscoveryRequest =
-                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, 8988, new ResponseListener() {
+                HttpPeerDiscoveryRequest.createCurrentPeersRequest(host, BabbleConstants.DISCOVERY_PORT(), new ResponseListener() {
             @Override
             public void onReceivePeers(List<Peer> peers) {
                 mRcvPeers = peers;

--- a/babble/src/androidTest/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceTest.java
+++ b/babble/src/androidTest/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceTest.java
@@ -34,6 +34,10 @@ import org.junit.runner.RunWith;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import io.mosaicnetworks.babble.node.BabbleConstants;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
@@ -55,9 +59,9 @@ public class ResolvedServiceTest {
         nsdServiceInfo.setServiceName(serviceName);
         nsdServiceInfo.setHost(inetAddress);
         nsdServiceInfo.setPort(port);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.APP_IDENTIFIER, appIdentifier);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_NAME, groupName);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_UID, groupUid);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_APP_LABEL, appIdentifier);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL, groupName);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL, groupUid);
 
         MdnsResolvedService resolvedService = new MdnsResolvedService(nsdServiceInfo);
 
@@ -84,13 +88,12 @@ public class ResolvedServiceTest {
         nsdServiceInfo.setServiceName(serviceName);
         nsdServiceInfo.setHost(inetAddress);
         nsdServiceInfo.setPort(port);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.APP_IDENTIFIER, appIdentifier);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_NAME, groupName);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_UID, groupUid);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_APP_LABEL, appIdentifier);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL, groupName);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL, groupUid);
+        ResolvedService resolvedService = ResolvedServiceMdnsFactory.NewJoinResolvedService("dp", nsdServiceInfo);
 
-        MdnsResolvedService resolvedService = new MdnsResolvedService(nsdServiceInfo);
-
-        MdnsResolvedGroup resolvedGroup = new MdnsResolvedGroup(resolvedService);
+        ResolvedGroup resolvedGroup = new ResolvedGroup(resolvedService);
 
         resolvedService.setResolvedGroup(resolvedGroup);
 
@@ -114,13 +117,12 @@ public class ResolvedServiceTest {
         nsdServiceInfo.setServiceName(serviceName);
         nsdServiceInfo.setHost(inetAddress);
         nsdServiceInfo.setPort(port);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.APP_IDENTIFIER, appIdentifier);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_NAME, groupName);
-        nsdServiceInfo.setAttribute(MdnsAdvertiser.GROUP_UID, groupUid);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_APP_LABEL, appIdentifier);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL, groupName);
+        nsdServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL, groupUid);
+        ResolvedService resolvedService = ResolvedServiceMdnsFactory.NewJoinResolvedService("dp", nsdServiceInfo);
 
-        MdnsResolvedService resolvedService = new MdnsResolvedService(nsdServiceInfo);
-
-        MdnsResolvedGroup resolvedGroup = new MdnsResolvedGroup(resolvedService);
+        ResolvedGroup resolvedGroup = new ResolvedGroup(resolvedService);
 
         resolvedService.setResolvedGroup(resolvedGroup);
         resolvedService.setResolvedGroup(resolvedGroup); //should throw an IllegalStateException

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -39,7 +39,6 @@ import io.mosaicnetworks.babble.configure.p2p.P2PJoinGroupFragment;
 import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.mdns.MdnsResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.p2p.P2PResolvedGroup;
 
 /**
@@ -187,12 +186,14 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
     @Override
     public void onServiceSelected(ResolvedGroup resolvedGroup) {
 
-        if (resolvedGroup instanceof MdnsResolvedGroup) {
+
+        //TODO: JK20Mar   this instanceof stuff will break
+        if (resolvedGroup instanceof ResolvedGroup) {
             Log.i(TAG, "onServiceSelected: MDNS item selected");
             MdnsJoinGroupFragment mJoinGroupMdnsFragment = MdnsJoinGroupFragment.newInstance(resolvedGroup);
             replaceFragment(mJoinGroupMdnsFragment, true);
         } else {
-            if (resolvedGroup instanceof P2PResolvedGroup) {
+            if (resolvedGroup instanceof ResolvedGroup) {
 
                 Log.i(TAG, "onServiceSelected: P2P item selected");
                 P2PJoinGroupFragment mJoinGroupP2PFragment = P2PJoinGroupFragment.newInstance(resolvedGroup);

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/BaseConfigActivity.java
@@ -187,13 +187,14 @@ public abstract class BaseConfigActivity extends AppCompatActivity implements On
     public void onServiceSelected(ResolvedGroup resolvedGroup) {
 
 
-        //TODO: JK20Mar   this instanceof stuff will break
-        if (resolvedGroup instanceof ResolvedGroup) {
+        // TODO: JK20Mar   this is a temporary hack
+        // At the moment the DataProviders are hardcoded as we don't yet have a DiscoveryDataController
+        if (resolvedGroup.getDataProviderId().equals("mdns")) {
             Log.i(TAG, "onServiceSelected: MDNS item selected");
             MdnsJoinGroupFragment mJoinGroupMdnsFragment = MdnsJoinGroupFragment.newInstance(resolvedGroup);
             replaceFragment(mJoinGroupMdnsFragment, true);
         } else {
-            if (resolvedGroup instanceof ResolvedGroup) {
+            if (resolvedGroup.getDataProviderId().equals("p2p")) {
 
                 Log.i(TAG, "onServiceSelected: P2P item selected");
                 P2PJoinGroupFragment mJoinGroupP2PFragment = P2PJoinGroupFragment.newInstance(resolvedGroup);

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/NewGroupFragment.java
@@ -41,6 +41,7 @@ import androidx.annotation.NonNull;
 import java.util.Objects;
 
 import io.mosaicnetworks.babble.R;
+import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.node.ConfigManager;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
@@ -189,7 +190,9 @@ public class NewGroupFragment extends BabbleServiceBinder {
 
         } else {
             mServiceAdvertiser = new MdnsAdvertiser2(mGroupDescriptor,
-                    getContext().getApplicationContext());
+                    getContext().getApplicationContext(),
+                    "", ""
+                    );  //TODO: JK20March
             configAndStartBabble(Utils.getIPAddr(getContext()));
         }
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/OnFragmentInteractionListener.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/OnFragmentInteractionListener.java
@@ -25,6 +25,7 @@
 package io.mosaicnetworks.babble.configure;
 
 import io.mosaicnetworks.babble.node.BabbleService;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 
 /**

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsDiscoveryFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsDiscoveryFragment.java
@@ -29,11 +29,8 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -41,6 +38,7 @@ import java.util.Objects;
 
 import io.mosaicnetworks.babble.R;
 import io.mosaicnetworks.babble.configure.OnFragmentInteractionListener;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ServicesListListener;
 import io.mosaicnetworks.babble.servicediscovery.mdns.MdnsServicesListView;

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsJoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/mdns/MdnsJoinGroupFragment.java
@@ -31,9 +31,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
-import androidx.appcompat.app.AlertDialog;
 
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -42,7 +40,6 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -60,8 +57,6 @@ import io.mosaicnetworks.babble.node.ConfigManager;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
-import io.mosaicnetworks.babble.servicediscovery.mdns.MdnsResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.mdns.MdnsResolvedService;
 import io.mosaicnetworks.babble.utils.DialogUtils;
 import io.mosaicnetworks.babble.utils.Utils;
 
@@ -81,8 +76,8 @@ public class MdnsJoinGroupFragment extends Fragment implements ResponseListener 
     private HttpPeerDiscoveryRequest mHttpGenesisPeerDiscoveryRequest;
     private HttpPeerDiscoveryRequest mHttpCurrentPeerDiscoveryRequest;
     private List<Peer> mGenesisPeers;
-    private MdnsResolvedGroup mResolvedGroup;
-    private MdnsResolvedService mResolvedService;
+    private ResolvedGroup mResolvedGroup;
+    private ResolvedService mResolvedService;
     private static Random randomGenerator = new Random();
 
     public MdnsJoinGroupFragment() {
@@ -98,7 +93,7 @@ public class MdnsJoinGroupFragment extends Fragment implements ResponseListener 
     public static MdnsJoinGroupFragment newInstance(ResolvedGroup resolvedGroup) {
         Log.i(TAG, "newInstance: "+ resolvedGroup.getGroupName());
         MdnsJoinGroupFragment mdnsJoinGroupFragment = new MdnsJoinGroupFragment();
-        mdnsJoinGroupFragment.mResolvedGroup = (MdnsResolvedGroup) resolvedGroup;
+        mdnsJoinGroupFragment.mResolvedGroup = resolvedGroup;
         return  mdnsJoinGroupFragment;
     }
 
@@ -157,11 +152,11 @@ public class MdnsJoinGroupFragment extends Fragment implements ResponseListener 
 
         //We are choosing a random resolved service - if we try again we may get a different
         //service.
-        mResolvedService = (MdnsResolvedService) resolvedServices.get(randomGenerator.nextInt(resolvedServices.size()));
+        mResolvedService = (ResolvedService) resolvedServices.get(randomGenerator.nextInt(resolvedServices.size()));
 
 
         final String peerIP = mResolvedService.getInetAddress().getHostAddress();
-        final int peerPort = mResolvedService.getPort();
+        final int peerPort = mResolvedService.getDiscoveryPort();
 
         // Store moniker and host entered
         SharedPreferences sharedPref = Objects.requireNonNull(getActivity()).getSharedPreferences(

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PDiscoveryFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PDiscoveryFragment.java
@@ -32,8 +32,6 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
@@ -41,6 +39,7 @@ import java.util.Objects;
 
 import io.mosaicnetworks.babble.R;
 import io.mosaicnetworks.babble.configure.OnFragmentInteractionListener;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ServicesListListener;
 import io.mosaicnetworks.babble.servicediscovery.p2p.P2PServicesListView;

--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PJoinGroupFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/p2p/P2PJoinGroupFragment.java
@@ -31,9 +31,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
-import androidx.appcompat.app.AlertDialog;
 
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -42,7 +40,6 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -58,11 +55,11 @@ import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.node.CannotStartBabbleNodeException;
 import io.mosaicnetworks.babble.node.ConfigManager;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedService;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
 import io.mosaicnetworks.babble.servicediscovery.p2p.P2PConnected;
-import io.mosaicnetworks.babble.servicediscovery.p2p.P2PResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.p2p.P2PResolvedService;
 import io.mosaicnetworks.babble.servicediscovery.p2p.P2PService;
 import io.mosaicnetworks.babble.utils.DialogUtils;
 import io.mosaicnetworks.babble.utils.Utils;
@@ -85,8 +82,8 @@ public class P2PJoinGroupFragment extends Fragment implements ResponseListener, 
     private HttpPeerDiscoveryRequest mHttpGenesisPeerDiscoveryRequest;
     private HttpPeerDiscoveryRequest mHttpCurrentPeerDiscoveryRequest;
     private List<Peer> mGenesisPeers;
-    private P2PResolvedGroup mResolvedGroup;
-    private P2PResolvedService mResolvedService;
+    private ResolvedGroup mResolvedGroup;
+    private ResolvedService mResolvedService;
 
     public P2PJoinGroupFragment() {
 
@@ -102,7 +99,7 @@ public class P2PJoinGroupFragment extends Fragment implements ResponseListener, 
     public static P2PJoinGroupFragment newInstance(ResolvedGroup resolvedGroup) {
         Log.i(TAG, "newInstance: "+ resolvedGroup.getGroupName());
         P2PJoinGroupFragment p2PJoinGroupFragment = new P2PJoinGroupFragment();
-        p2PJoinGroupFragment.mResolvedGroup = (P2PResolvedGroup) resolvedGroup;
+        p2PJoinGroupFragment.mResolvedGroup = resolvedGroup;
         return  p2PJoinGroupFragment;
     }
 
@@ -162,9 +159,9 @@ public class P2PJoinGroupFragment extends Fragment implements ResponseListener, 
 
 
         // For P2P only one node advertises.
-        mResolvedService = (P2PResolvedService) resolvedServices.get(0);
+        mResolvedService =  resolvedServices.get(0);
         final String peerIP = mResolvedService.getInetAddress().getHostAddress();
-        final int peerPort = mResolvedService.getPort();
+        final int peerPort = mResolvedService.getDiscoveryPort();
         final String deviceAddress = mResolvedService.getGroupUid();
 
         // Store moniker and host entered

--- a/babble/src/main/java/io/mosaicnetworks/babble/discovery/PeersFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/discovery/PeersFactory.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.discovery;
+
+import com.google.gson.Gson;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This abstract class provides methods to convert a List<Peer> to a JSON String
+ * and vice versa
+ */
+public abstract class PeersFactory {
+    private static Gson gson = new Gson();
+
+    /**
+     * Exports List of Peers to Json
+     *
+     * @param peers
+     * @return
+     */
+    public static String toJson(List<Peer> peers) {
+            return gson.toJson(peers);
+    }
+
+    /**
+     * Converts a JSON string into an array of {@link Peer}
+     *
+     * @param peersJson
+     * @return
+     */
+    public static Peer[] toPeersArray(String peersJson) {
+        return gson.fromJson(peersJson, Peer[].class);
+    }
+
+
+    /**
+     * Converts a JSON string into a list of {@link Peer}
+     *
+     * @param peersJson
+     * @return
+     */
+    public static List<Peer> toPeersList(String peersJson) {
+        return new ArrayList<>(Arrays.asList(toPeersArray(peersJson)));
+    }
+
+
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleConstants.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleConstants.java
@@ -47,6 +47,17 @@ public class BabbleConstants {
     public static int BABBLE_PORT() {return INSTANCE.BABBLE_PORT;}
 
     /**
+     * The port used by the discovery end point. NB not the WebRTC disco
+     * server
+     *
+     * Set in {@link io.mosaicnetworks.babble.R.integer#babble_discovery_port}
+     *
+     * @return the discovery port
+     */
+    public static int DISCOVERY_PORT() {return INSTANCE.DISCOVERY_PORT;}
+
+
+    /**
      * The app id used by Babble identify itself (and ignore other app Ids).
      * If this field is set to an empty string, this is set to the app package
      * name.
@@ -93,9 +104,73 @@ public class BabbleConstants {
      */
     public static String PRIV_KEY() {return INSTANCE.PRIV_KEY;}
 
+    /**
+     * The service type to use for discovery
+     */
+    public static String SERVICE_TYPE() {return INSTANCE.SERVICE_TYPE;}
+
+    /**
+     * The service type to use for p2p discovery
+     */
+    public static String P2P_SERVICE_TYPE() {return INSTANCE.P2P_SERVICE_TYPE;}
+
+
+
+    /*----------------------------------------------------------------------------*/
+    //           Network Type
+    /*----------------------------------------------------------------------------*/
+
+
+    /**
+     * Archive discovery type
+     */
+    public final static int NETWORK_NONE = 0;
+    /**
+     * mDNS / WiFi discovery type
+     */
+    public final static int NETWORK_WIFI = 1;
+    /**
+     * P2P / WiFi Direct discovery type
+     *
+     */
+    public final static int NETWORK_P2P = 2;
+    /**
+     * Global / WebRTC discovery type
+     */
+    public final static int NETWORK_GLOBAL = 3;
+
+
+
+    /*----------------------------------------------------------------------------*/
+    //           DNS TXT Constants
+    /*----------------------------------------------------------------------------*/
+
+
+    public final static String DNS_TXT_HOST_LABEL = "host";
+    public final static String DNS_TXT_PORT_LABEL = "port";
+    public final static String DNS_TXT_MONIKER_LABEL = "moniker";
+    public final static String DNS_TXT_DNS_VERSION_LABEL = "textvers";
+    public final static String DNS_TXT_BABBLE_VERSION_LABEL = "babblevers";
+    public final static String DNS_TXT_GROUP_ID_LABEL = "groupid";
+    public final static String DNS_TXT_APP_LABEL = "app";
+    public final static String DNS_TXT_GROUP_LABEL = "group";
+    public final static String DNS_TXT_CURRENT_PEERS_LABEL = "peers";
+    public final static String DNS_TXT_INITIAL_PEERS_LABEL = "initpeers";
+
+
+
+    public final static int P2P_RETRY_DELAY_MS = 1000;
+    public final static int P2P_RETRY_LIMIT = 4;
+
+    public final static String DEFAULT_P2P_IP_PREFIX = "192.168.49.";
+    public final static String DEFAULT_P2P_IP_ADDRESS = DEFAULT_P2P_IP_PREFIX+"1";
+
+
+
 
 
     public final int BABBLE_PORT;
+    public final int DISCOVERY_PORT;
     public final String APP_ID;
     public final String BABBLE_ROOTDIR;
     public final String DB_SUBDIR;
@@ -104,6 +179,8 @@ public class BabbleConstants {
     public final String PEERS_JSON;
     public final String PEERS_GENESIS_JSON;
     public final String PRIV_KEY;
+    public final String SERVICE_TYPE;
+    public final String P2P_SERVICE_TYPE;
 
 
     private static BabbleConstants INSTANCE;
@@ -135,6 +212,7 @@ public class BabbleConstants {
         Context appContext = context.getApplicationContext();
 
         BABBLE_PORT = context.getResources().getInteger(R.integer.babble_port);
+        DISCOVERY_PORT = context.getResources().getInteger(R.integer.babble_discovery_port);
         BABBLE_ROOTDIR = context.getResources().getString(R.string.babble_root_dir);
         DB_SUBDIR = context.getResources().getString(R.string.babble_db_subdir);
 
@@ -143,6 +221,8 @@ public class BabbleConstants {
         PEERS_GENESIS_JSON = context.getResources().getString(R.string.babble_peers_genesis_json);
         PRIV_KEY = context.getResources().getString(R.string.babble_priv_key);
 
+        SERVICE_TYPE = context.getResources().getString(R.string.babble_service_type);
+        P2P_SERVICE_TYPE = context.getResources().getString(R.string.babble_p2p_service_type);
 
         String appId = context.getResources().getString(R.string.babble_app_id);
         if (appId.equals("")) {

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
@@ -65,11 +65,6 @@ public abstract class BabbleService<AppState extends BabbleState> {
         this.mNetworkType = mNetworkType;
     }
 
-    public final static int NETWORK_WIFI = 1;
-    public final static int NETWORK_P2P = 2;
-    public final static int NETWORK_NONE = 0;
-
-
     protected int mNetworkType;
 
     public final static String BABBLE_VERSION = BuildConfig.BabbleVersion;
@@ -92,7 +87,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
      * @throws IllegalStateException if the service is currently running
      */
     public void start(String configDirectory, GroupDescriptor groupDescriptor) {
-        start(configDirectory, groupDescriptor, NETWORK_WIFI);  // Defaults to the original mDNS configuration
+        start(configDirectory, groupDescriptor, BabbleConstants.NETWORK_WIFI);  // Defaults to the original mDNS configuration
     }
 
 
@@ -100,7 +95,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
      * Start the service
      *
      * @param configDirectory The full path to the babble configuration directory
-     * @param networkType BabbleService.NETWORK_NONE for archive, NETWORK_WIFI or NETWORK_P2P for mDNS or WiFi Direct
+     * @param networkType BabbleConstants.NETWORK_NONE for archive, NETWORK_WIFI or NETWORK_P2P for mDNS or WiFi Direct
      * @throws IllegalStateException if the service is currently running
      */
     public void start(String configDirectory, int networkType) {
@@ -114,7 +109,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
      *
      * @param configDirectory The full path to the babble configuration directory
      * @param groupDescriptor The group descriptor
-     * @param networkType BabbleService.NETWORK_NONE for archive, NETWORK_WIFI or NETWORK_P2P for mDNS or WiFi Direct
+     * @param networkType BabbleConstants.NETWORK_NONE for archive, NETWORK_WIFI or NETWORK_P2P for mDNS or WiFi Direct
      * @throws IllegalStateException if the service is currently running
      */
     public void start(String configDirectory, GroupDescriptor groupDescriptor, int networkType) {

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/BabbleService.java
@@ -30,6 +30,8 @@ import android.util.Log;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.mosaicnetworks.babble.BuildConfig;
+
 /**
  * This is a wrapper around {@link BabbleNode} to allow the node to run as a pseudo service. Beyond
  * what a {@link BabbleNode} provides, this class:
@@ -70,10 +72,7 @@ public abstract class BabbleService<AppState extends BabbleState> {
 
     protected int mNetworkType;
 
-    //TODO: populate this from Gradle
-    public final static String BABBLE_VERSION = "0.6.2";
-
-
+    public final static String BABBLE_VERSION = BuildConfig.BabbleVersion;
 
     /**
      * The underlying app state, to which babble transactions are applied

--- a/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/node/ConfigManager.java
@@ -107,7 +107,7 @@ public final class ConfigManager {
 
         Log.v("ConfigManager", "got FilesDir");
 
-        mAppId = appContext.getPackageName();
+        mAppId = BabbleConstants.APP_ID();  //TODO: JK20Mar remove this variable and use constant direct
 
         Log.v("ConfigManager", "got Package Name");
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/InterfaceResolvedGroup.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/InterfaceResolvedGroup.java
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery;
+
+import java.util.List;
+
+public interface InterfaceResolvedGroup {
+    void addService(InterfaceResolvedService resolvedService);
+    boolean removeService(InterfaceResolvedService resolvedService);
+    List<InterfaceResolvedService> getResolvedServices();
+    String getGroupName();
+    String getGroupUid();
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/InterfaceResolvedService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/InterfaceResolvedService.java
@@ -1,0 +1,37 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery;
+
+import java.net.InetAddress;
+
+public interface InterfaceResolvedService {
+    InterfaceResolvedGroup getResolvedGroup();
+    void setResolvedGroup(InterfaceResolvedGroup resolvedGroup);
+    String getAppIdentifier();
+    String getGroupName();
+    String getGroupUid();
+    InetAddress getInetAddress();
+    int getPort();
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/ResolvedGroup.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/ResolvedGroup.java
@@ -24,12 +24,135 @@
 
 package io.mosaicnetworks.babble.servicediscovery;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
-public interface ResolvedGroup {
-    void addService(ResolvedService resolvedService);
-    boolean removeService(ResolvedService resolvedService);
-    List<ResolvedService> getResolvedServices();
-    String getGroupName();
-    String getGroupUid();
+
+/**
+ * This represents a group of resolved services with the same group UID. Services with a matching
+ * group UID and group name can be added to the group as they're discovered. Services can be removed
+ * from the group as and when they are lost.
+ */
+public final class ResolvedGroup  {
+
+    private String mMoniker = "";
+    private final String mGroupName;
+    private final String mGroupUid;
+    private final String mDataProviderId;
+    private final List<ResolvedService> mResolvedServices = new ArrayList<>();
+    private static Random randomGenerator = new Random();
+
+    /**
+     * Constructor, the group is initialised from a resolved service
+     * @param resolvedService a resolved service used to initialise the group
+     */
+    public ResolvedGroup(ResolvedService resolvedService) {
+        mGroupName = resolvedService.getGroupName();
+        mGroupUid = resolvedService.getGroupUid();
+        mDataProviderId = resolvedService.getDataProviderId();
+        mResolvedServices.add(resolvedService);
+    }
+
+    /**
+     * Adds a resolved service to this group's list of resolved services
+     * @param resolvedService
+     */
+    public void addService(ResolvedService resolvedService) {
+        if (mResolvedServices.contains(resolvedService)) {
+            throw new IllegalArgumentException("Cannot add service: Group already contains this service");
+        }
+
+        if (!resolvedService.getGroupUid().equals(mGroupUid)) {
+            throw new IllegalArgumentException("Cannot add service: Service group UID does not match this group's UID");
+        }
+
+        if (!resolvedService.getGroupName().equals(mGroupName)) {
+            throw new IllegalArgumentException("Cannot add service: Service group name does not match this group's name");
+        }
+
+        mResolvedServices.add(resolvedService);
+    }
+
+
+    /**
+     * Returns a random service from the mResolvedServices
+     * @return
+     */
+    public ResolvedService getRandomService() {
+        return mResolvedServices.get(randomGenerator.nextInt(mResolvedServices.size()));
+    }
+
+
+    /**
+     * Removes a resolved service from this group's list of resolved services
+     * @param resolvedService the service to be removed
+     * @return
+     */
+    public boolean removeService(ResolvedService resolvedService) {
+
+        if (!mResolvedServices.contains(resolvedService)) {
+            throw new IllegalArgumentException("Cannot remove service: Group does not contain this service");
+        }
+
+        mResolvedServices.remove(resolvedService);
+
+        return mResolvedServices.isEmpty();
+    }
+
+    /**
+     * Get the list of resolved services associated with this group
+     * @return a shallow copy of the list of services associated with this group
+     */
+    public List<ResolvedService> getResolvedServices() {
+        return new ArrayList<>(mResolvedServices);
+    }
+
+    /**
+     * Get the group name
+     * @return the group name
+     */
+    public String getGroupName() {
+        return mGroupName;
+    }
+
+    /**
+     * Get the group UID
+     * @return the group UID
+     */
+    public String getGroupUid() {
+        return mGroupUid;
+    }
+
+    /**
+     * Get the Data Provider ID
+     * @return  Data Provider ID
+     */
+    public String getDataProviderId() {
+        return mDataProviderId;
+    }
+
+
+    /**
+     * This will not be set until after the service has been selected
+     *
+     * @return
+     */
+    public String getMoniker() {
+        return mMoniker;
+    }
+
+
+    /**
+     * Unlike all of the other properties of ResolvedGroup and {@link ResolvedService},
+     * moniker is not final as it is set after the Discovery phase. It is the additional
+     * information that is required to build a babble configuration
+     *
+     * @param mMoniker
+     */
+    public void setMoniker(String mMoniker) {
+        this.mMoniker = mMoniker;
+    }
+
+
 }

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/ResolvedService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/ResolvedService.java
@@ -24,14 +24,193 @@
 
 package io.mosaicnetworks.babble.servicediscovery;
 
-import java.net.InetAddress;
+import android.net.nsd.NsdServiceInfo;
 
-public interface ResolvedService {
-    ResolvedGroup getResolvedGroup();
-    void setResolvedGroup(ResolvedGroup resolvedGroup);
-    String getAppIdentifier();
-    String getGroupName();
-    String getGroupUid();
-    InetAddress getInetAddress();
-    int getPort();
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Map;
+
+import io.mosaicnetworks.babble.discovery.Peer;
+
+/**
+ * A class representing service information for network service discovery. Unlike the
+ * {@link NsdServiceInfo} class this class unpacks the data in the TXT record into class properties.
+ * In this sense it holds NSD info specific to this app's service.
+ *
+ * Several instances of this class may refer to the same group that are advertised by a different
+ * hosts. Instances of the {@link ResolvedGroup} class can be used to hold a collection of
+ * {@link ResolvedService} that represent the same group. In this sense a {@link ResolvedService} is
+ * assigned to a group. This assignment can be set by calling the
+ * {@link #setResolvedGroup(ResolvedGroup)} method.
+ */
+public final class ResolvedService {
+
+
+    public static final String SERVICE_TYPE = "_babble._tcp.";
+    public static final String APP_IDENTIFIER = "appIdentifier";
+    public static final String GROUP_NAME = "groupName";
+    public static final String GROUP_UID = "groupUid";
+
+
+    private final String mDataProviderId;
+    private final InetAddress mInetAddress;
+    private final String mInetString;
+
+    private final int mDiscoveryPort;
+    private final int mBabblePort;
+
+    private final String mAppIdentifier;
+    private final String mGroupName;
+    private final String mGroupUid;
+    private ResolvedGroup mResolvedGroup;
+    private final Map<String, String> mServiceAttributes;
+    private final List<Peer> mInitialPeers;
+    private final List<Peer> mCurrentPeers;
+
+
+
+    private boolean mAssignedGroup = false;
+
+    public ResolvedService(String dataProviderId, InetAddress inetAddress,
+                           String inetString,
+                           int babblePort, int discoveryPort, Map<String,
+                           String> serviceAttributes, String appIdentifier, String groupName,
+                           String groupUID, List<Peer> initialPeers,
+                           List<Peer> currentPeers ) {
+        this.mInetAddress = inetAddress;
+        this.mBabblePort = babblePort;
+        this.mDiscoveryPort = discoveryPort;
+        this.mServiceAttributes = serviceAttributes;
+        this.mAppIdentifier = appIdentifier;
+        this.mGroupName = groupName;
+        this.mGroupUid = groupUID;
+        this.mDataProviderId = dataProviderId;
+        this.mInitialPeers = initialPeers;
+        this.mCurrentPeers = currentPeers;
+
+        if (inetString.equals("")) {
+            this.mInetString = mInetAddress.getHostAddress();
+        } else {
+            this.mInetString = inetString;
+        }
+
+    }
+
+
+    /**
+     * Returns the given attribute. If the attribute is not set, it returns an empty string
+     *
+     * @param key
+     * @return
+     */
+    public String getAttribute(String key) {
+        if (mServiceAttributes.containsKey(key)) {
+            return mServiceAttributes.get(key);
+        }
+
+        return "";
+    }
+
+
+    /**
+     * Get the group to which this instance has been assigned
+     * @return the reoslved group
+     */
+    public ResolvedGroup getResolvedGroup() {
+        return mResolvedGroup;
+    }
+
+    /**
+     * Assign this service to a group. This can only be done once, attempts to re-assign will result
+     * in an {@link IllegalStateException}.
+     * @param resolvedGroup the group to which the service should be assigned
+     */
+    public void setResolvedGroup(ResolvedGroup resolvedGroup) {
+
+        if (mAssignedGroup) {
+            throw new IllegalStateException("This service has already been assigned to a group");
+        }
+
+        mResolvedGroup =  resolvedGroup;
+        mAssignedGroup = true;
+
+    }
+
+    /**
+     * Get the app identifier
+     * @return app identifier
+     */
+    public String getAppIdentifier() {
+        return mAppIdentifier;
+    }
+
+    /**
+     * Get the group name
+     * @return group name
+     */
+    public String getGroupName() {
+        return mGroupName;
+    }
+
+    /**
+     * Get the group UID
+     * @return group UID
+     */
+    public String getGroupUid() {
+        return mGroupUid;
+    }
+
+    /**
+     * Get the Data Provider ID
+     * @return  Data Provider ID
+     */
+    public String getDataProviderId() {
+        return mDataProviderId;
+    }
+
+    /**
+     * Get the inet address
+     * @return
+     */
+    public InetAddress getInetAddress() {
+        return mInetAddress;
+    }
+
+    /**
+     * Get the discovery port
+     * @return the discovery port
+     */
+    public int getDiscoveryPort() {
+        return mDiscoveryPort;
+    }
+
+    /**
+     * Get the babble port
+     * @return the babble port
+     */
+    public int getBabblePort() {
+        return mBabblePort;
+    }
+
+
+    /**
+     * Gets the string representation of the InetAddress. For some protocols
+     * such as WebRTC, this is used for the NetAddr field as the underlying
+     * field will not be an IP address (it uses a public key instead).
+     *
+     * @return
+     */
+    public String getInetString() {
+        return mInetString;
+    }
+
+    //TODO: Javadocs
+
+    public List<Peer> getInitialPeers() {
+        return mInitialPeers;
+    }
+
+    public List<Peer> getCurrentPeers() {
+        return mCurrentPeers;
+    }
 }

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser.java
@@ -30,38 +30,39 @@ import android.net.nsd.NsdServiceInfo;
 
 import java.util.Objects;
 
+import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
 import io.mosaicnetworks.babble.servicediscovery.ServiceAdvertiser;
 import io.mosaicnetworks.babble.utils.RandomString;
 
 public class MdnsAdvertiser implements ServiceAdvertiser  {
 
-    public static final String SERVICE_TYPE = "_babble._tcp.";
-    public static final String APP_IDENTIFIER = "appIdentifier";
-    public static final String GROUP_NAME = "groupName";
-    public static final String GROUP_UID = "groupUid";
     private NsdManager mNsdManager;
     private NsdManager.RegistrationListener mRegistrationListener;
     private String mServiceName;
     private NsdServiceInfo mServiceInfo = new NsdServiceInfo();
     private Context mAppContext;
 
-    public MdnsAdvertiser(GroupDescriptor groupDescriptor, int port, Context context) {
+    public MdnsAdvertiser(GroupDescriptor groupDescriptor, int port, Context context, String currentPeers,
+                          String initPeers) {
         initializeRegistrationListener();
 
         mAppContext = context.getApplicationContext();
-        mServiceInfo.setServiceType(SERVICE_TYPE);
+        mServiceInfo.setServiceType(BabbleConstants.SERVICE_TYPE());
         mServiceName = new RandomString(32).nextString();
         mServiceInfo.setServiceName(mServiceName);
-        mServiceInfo.setAttribute(APP_IDENTIFIER, mAppContext.getPackageName());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_APP_LABEL, BabbleConstants.APP_ID());
         // https://developer.android.com/studio/build/application-id note: The application ID
         // used to be directly tied to your code's package name; so some Android APIs use the term
         // "package name" in their method names and parameter names, but this is actually your
         // application ID. For example, the Context.getPackageName() method
         // returns your application ID
-        mServiceInfo.setAttribute(GROUP_NAME, groupDescriptor.getName());
-        mServiceInfo.setAttribute(GROUP_UID, groupDescriptor.getUid());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL, groupDescriptor.getName());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL, groupDescriptor.getUid());
         mServiceInfo.setPort(port);
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_CURRENT_PEERS_LABEL, currentPeers);
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_INITIAL_PEERS_LABEL, initPeers);
+
     }
 
     public void advertise() {

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsAdvertiser2.java
@@ -34,17 +34,14 @@ import java.util.Objects;
 
 import io.mosaicnetworks.babble.discovery.HttpPeerDiscoveryServer;
 import io.mosaicnetworks.babble.discovery.PeersProvider;
+import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.node.GroupDescriptor;
 import io.mosaicnetworks.babble.service.ServiceAdvertiser;
 import io.mosaicnetworks.babble.utils.RandomString;
 
 public class MdnsAdvertiser2 implements ServiceAdvertiser {
 
-    public static final String SERVICE_TYPE = "_babble._tcp.";
-    public static final String APP_IDENTIFIER = "appIdentifier";
-    public static final String GROUP_NAME = "groupName";
-    public static final String GROUP_UID = "groupUid";
-    private static int sDiscoveryPort = 8988;
+    private static int sDiscoveryPort = BabbleConstants.DISCOVERY_PORT();
     private NsdManager mNsdManager;
     private NsdManager.RegistrationListener mRegistrationListener;
     private String mServiceName;
@@ -54,22 +51,25 @@ public class MdnsAdvertiser2 implements ServiceAdvertiser {
     private String mCurrentPeers;
     private boolean mAdvertising = false;
 
-    public MdnsAdvertiser2(GroupDescriptor groupDescriptor, Context context) {
+    public MdnsAdvertiser2(GroupDescriptor groupDescriptor, Context context, String currentPeers,
+                           String initPeers) {
         initializeRegistrationListener();
 
         mAppContext = context.getApplicationContext();
-        mServiceInfo.setServiceType(SERVICE_TYPE);
+        mServiceInfo.setServiceType(BabbleConstants.SERVICE_TYPE());
         mServiceName = new RandomString(32).nextString();
         mServiceInfo.setServiceName(mServiceName);
-        mServiceInfo.setAttribute(APP_IDENTIFIER, mAppContext.getPackageName());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_APP_LABEL, BabbleConstants.APP_ID());
         // https://developer.android.com/studio/build/application-id note: The application ID
         // used to be directly tied to your code's package name; so some Android APIs use the term
         // "package name" in their method names and parameter names, but this is actually your
         // application ID. For example, the Context.getPackageName() method
         // returns your application ID
-        mServiceInfo.setAttribute(GROUP_NAME, groupDescriptor.getName());
-        mServiceInfo.setAttribute(GROUP_UID, groupDescriptor.getUid());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL, groupDescriptor.getName());
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL, groupDescriptor.getUid());
         mServiceInfo.setPort(sDiscoveryPort);
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_CURRENT_PEERS_LABEL, currentPeers);
+        mServiceInfo.setAttribute(BabbleConstants.DNS_TXT_INITIAL_PEERS_LABEL, initPeers);
     }
 
     @Override

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsResolvedGroup.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsResolvedGroup.java
@@ -27,7 +27,8 @@ package io.mosaicnetworks.babble.servicediscovery.mdns;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedService;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
 
 /**
@@ -35,7 +36,7 @@ import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
  * group UID and group name can be added to the group as they're discovered. Services can be removed
  * from the group as and when they are lost.
  */
-public final class MdnsResolvedGroup implements ResolvedGroup {
+public final class MdnsResolvedGroup  {
 
     private final String mGroupName;
     private final String mGroupUid;
@@ -48,7 +49,7 @@ public final class MdnsResolvedGroup implements ResolvedGroup {
     public MdnsResolvedGroup(ResolvedService resolvedService) {
         mGroupName = resolvedService.getGroupName();
         mGroupUid = resolvedService.getGroupUid();
-        mResolvedServices.add((MdnsResolvedService)resolvedService);
+        mResolvedServices.add(resolvedService);
     }
 
     /**
@@ -68,7 +69,7 @@ public final class MdnsResolvedGroup implements ResolvedGroup {
             throw new IllegalArgumentException("Cannot add service: Service group name does not match this group's name");
         }
 
-        mResolvedServices.add((MdnsResolvedService)resolvedService);
+        mResolvedServices.add(resolvedService);
     }
 
     /**

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsResolvedService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsResolvedService.java
@@ -30,12 +30,8 @@ import java.net.InetAddress;
 import java.nio.charset.Charset;
 import java.util.Map;
 
+import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
-
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.APP_IDENTIFIER;
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROUP_NAME;
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROUP_UID;
 
 /**
  * A class representing service information for network service discovery. Unlike the
@@ -44,18 +40,16 @@ import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROU
  *
  * Several instances of this class may refer to the same group that are advertised by a different
  * hosts. Instances of the {@link MdnsResolvedGroup} class can be used to hold a collection of
- * {@link MdnsResolvedService} that represent the same group. In this sense a {@link MdnsResolvedService} is
- * assigned to a group. This assignment can be set by calling the
- * {@link #setResolvedGroup(MdnsResolvedGroup)} method.
+ * {@link MdnsResolvedService} that represent the same group.
  */
-public final class MdnsResolvedService implements ResolvedService {
+public final class MdnsResolvedService  {
     
     private final InetAddress mInetAddress;
     private final int mPort;
     private final String mAppIdentifier;
     private final String mGroupName;
     private final String mGroupUid;
-    private MdnsResolvedGroup mResolvedGroup;
+    private ResolvedGroup mResolvedGroup;
     private final Map<String, byte[]> mServiceAttributes;
     private boolean mAssignedGroup = false;
 
@@ -67,9 +61,9 @@ public final class MdnsResolvedService implements ResolvedService {
         mInetAddress = nsdServiceInfo.getHost();
         mPort = nsdServiceInfo.getPort();
         mServiceAttributes = nsdServiceInfo.getAttributes(); //Min Level API 21
-        mAppIdentifier = extractStringAttribute(APP_IDENTIFIER);
-        mGroupName = extractStringAttribute(GROUP_NAME);
-        mGroupUid = extractStringAttribute(GROUP_UID);
+        mAppIdentifier = extractStringAttribute(BabbleConstants.DNS_TXT_APP_LABEL);
+        mGroupName = extractStringAttribute(BabbleConstants.DNS_TXT_GROUP_LABEL);
+        mGroupUid = extractStringAttribute(BabbleConstants.DNS_TXT_GROUP_ID_LABEL);
     }
 
 
@@ -90,7 +84,7 @@ public final class MdnsResolvedService implements ResolvedService {
      * Get the group to which this instance has been assigned
      * @return the reoslved group
      */
-    public MdnsResolvedGroup getResolvedGroup() {
+    public ResolvedGroup getResolvedGroup() {
         return mResolvedGroup;
     }
 
@@ -105,7 +99,7 @@ public final class MdnsResolvedService implements ResolvedService {
             throw new IllegalStateException("This service has already been assigned to a group");
         }
 
-        mResolvedGroup = (MdnsResolvedGroup) resolvedGroup;
+        mResolvedGroup = resolvedGroup;
         mAssignedGroup = true;
 
     }

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsServicesListAdapter.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsServicesListAdapter.java
@@ -36,6 +36,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.List;
 
 import io.mosaicnetworks.babble.R;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 
 public class MdnsServicesListAdapter extends RecyclerView.Adapter<MdnsServicesListAdapter.ViewHolder> {
 
@@ -57,11 +58,11 @@ public class MdnsServicesListAdapter extends RecyclerView.Adapter<MdnsServicesLi
         }
     }
 
-    private List<MdnsResolvedGroup> mData;
+    private List<ResolvedGroup> mData;
     private LayoutInflater mInflater;
     private ItemClickListener mClickListener;
 
-    public MdnsServicesListAdapter(Context context, List<MdnsResolvedGroup> data) {
+    public MdnsServicesListAdapter(Context context, List<ResolvedGroup> data) {
         this.mInflater = LayoutInflater.from(context);
         this.mData = data;
     }
@@ -77,7 +78,7 @@ public class MdnsServicesListAdapter extends RecyclerView.Adapter<MdnsServicesLi
     // binds the data to the TextView in each row
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-        MdnsResolvedGroup groupInfo = mData.get(position);
+        ResolvedGroup groupInfo = mData.get(position);
 
         holder.groupUidTextView.setText(groupInfo.getGroupUid());
         holder.serviceNameTextView.setText(groupInfo.getGroupName());
@@ -94,7 +95,7 @@ public class MdnsServicesListAdapter extends RecyclerView.Adapter<MdnsServicesLi
     }
 
     // convenience method for getting data at click position
-    public MdnsResolvedGroup getItem(int id) {
+    public ResolvedGroup getItem(int id) {
         return mData.get(id);
     }
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/MdnsServicesListView.java
@@ -37,13 +37,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ServiceDiscoveryListener;
 import io.mosaicnetworks.babble.servicediscovery.ServicesListListener;
 
 public class MdnsServicesListView extends RecyclerView {
 
 
-    private List<MdnsResolvedGroup> mServiceInfoList = new ArrayList<>();
+    private List<ResolvedGroup> mServiceInfoList = new ArrayList<>();
     private ServicesListListener mServicesListListener;
     private MdnsDiscovery mMdnsDiscovery;
     private boolean mPrevIsEmpty = true;

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceMdnsFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceMdnsFactory.java
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery.mdns;
+
+import android.net.nsd.NsdServiceInfo;
+import android.util.Log;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.mosaicnetworks.babble.node.BabbleConstants;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
+
+public abstract class ResolvedServiceMdnsFactory {
+
+    public static ResolvedService NewJoinResolvedService(String dataProviderId, NsdServiceInfo nsdServiceInfo) {
+        Map<String, byte[]> serviceAttributes = nsdServiceInfo.getAttributes();
+
+        Log.i("ResolvedServiceMdnsFac", "NewJoinResolvedService: ");
+
+        return new ResolvedService(dataProviderId,
+                nsdServiceInfo.getHost(),
+                "",
+                BabbleConstants.BABBLE_PORT(),
+                nsdServiceInfo.getPort(),
+                convertAttributeMap(serviceAttributes),
+                extractStringAttribute(serviceAttributes, BabbleConstants.DNS_TXT_APP_LABEL),
+                extractStringAttribute(serviceAttributes, BabbleConstants.DNS_TXT_GROUP_LABEL),
+                extractStringAttribute(serviceAttributes, BabbleConstants.DNS_TXT_GROUP_ID_LABEL),
+                null, null   //TODO: expand this
+        );
+    }
+
+
+    private static String extractStringAttribute(Map<String, byte[]> serviceAttributes, String key) {
+        if (!serviceAttributes.containsKey(key)) {
+            throw new IllegalArgumentException("Map does not contain attribute: " + key);
+        }
+        //TODO: "This method always replaces malformed-input and unmappable-character sequences with
+        // this charset's default replacement string" - is this ok?
+        // The impact would be a fallback default value for these fields in the event that they could
+        // not be retrieved. But in those circumstances another error has probably already been thrown.
+        return new String(serviceAttributes.get(key), Charset.forName("UTF-8"));
+    }
+
+    /**
+     * Converts a Map of byte array to a map of String.
+     * @param serviceAttributes
+     * @return
+     */
+    private static Map<String, String> convertAttributeMap(Map<String, byte[]> serviceAttributes) {
+        Map<String, String> stringMap = new HashMap<>();
+
+        for (Map.Entry<String,byte[]> entry : serviceAttributes.entrySet())
+        {
+            stringMap.put(entry.getKey(), new String(entry.getValue(), Charset.forName("UTF-8"))  );
+        }
+
+        return stringMap;
+    }
+}

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceMdnsFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/mdns/ResolvedServiceMdnsFactory.java
@@ -74,9 +74,22 @@ public abstract class ResolvedServiceMdnsFactory {
     private static Map<String, String> convertAttributeMap(Map<String, byte[]> serviceAttributes) {
         Map<String, String> stringMap = new HashMap<>();
 
+        if (serviceAttributes == null ) {
+            Log.e("ResolvedServMdnsFac", "convertAttributeMap: serviceAttribute is null" );
+            return stringMap;
+        }
         for (Map.Entry<String,byte[]> entry : serviceAttributes.entrySet())
         {
-            stringMap.put(entry.getKey(), new String(entry.getValue(), Charset.forName("UTF-8"))  );
+
+            byte[] bytesValue = entry.getValue();
+
+            //Need to explicitly check for null, as it causes an error in string construction
+            if (bytesValue == null) {
+                stringMap.put(entry.getKey(), "");
+
+            } else {
+                stringMap.put(entry.getKey(), new String(bytesValue, Charset.forName("UTF-8")));
+            }
         }
 
         return stringMap;

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PResolvedGroup.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PResolvedGroup.java
@@ -27,25 +27,25 @@ package io.mosaicnetworks.babble.servicediscovery.p2p;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedService;
 
 /**
  * This represents a group of resolved services with the same group UID. Services with a matching
  * group UID and group name can be added to the group as they're discovered. Services can be removed
  * from the group as and when they are lost.
  */
-public final class P2PResolvedGroup implements ResolvedGroup {
+public final class P2PResolvedGroup implements InterfaceResolvedGroup {
 
     private final String mGroupName;
     private final String mGroupUid;
-    private final List<ResolvedService> mResolvedServices = new ArrayList<>();
+    private final List<InterfaceResolvedService> mResolvedServices = new ArrayList<>();
 
     /**
      * Constructor, the group is initialised from a resolved service
      * @param resolvedService a resolved service used to initialise the group
      */
-    public P2PResolvedGroup(ResolvedService resolvedService) {
+    public P2PResolvedGroup(InterfaceResolvedService resolvedService) {
         mGroupName = resolvedService.getGroupName();
         mGroupUid = resolvedService.getGroupUid();
         mResolvedServices.add(resolvedService);
@@ -55,7 +55,7 @@ public final class P2PResolvedGroup implements ResolvedGroup {
      * Adds a resolved service to this group's list of resolved services
      * @param resolvedService
      */
-    public void addService(ResolvedService resolvedService) {
+    public void addService(InterfaceResolvedService resolvedService) {
         if (mResolvedServices.contains(resolvedService)) {
             throw new IllegalArgumentException("Cannot add service: Group already contains this service");
         }
@@ -76,7 +76,7 @@ public final class P2PResolvedGroup implements ResolvedGroup {
      * @param resolvedService the service to be removed
      * @return
      */
-    public boolean removeService(ResolvedService resolvedService) {
+    public boolean removeService(InterfaceResolvedService resolvedService) {
 
         if (!mResolvedServices.contains(resolvedService)) {
             throw new IllegalArgumentException("Cannot remove service: Group does not contain this service");
@@ -91,7 +91,7 @@ public final class P2PResolvedGroup implements ResolvedGroup {
      * Get the list of resolved services associated with this group
      * @return a shallow copy of the list of services associated with this group
      */
-    public List<ResolvedService> getResolvedServices() {
+    public List<InterfaceResolvedService> getResolvedServices() {
         return new ArrayList<>(mResolvedServices);
     }
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PResolvedService.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PResolvedService.java
@@ -31,13 +31,10 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
-import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
+import io.mosaicnetworks.babble.node.BabbleConstants;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedGroup;
+import io.mosaicnetworks.babble.servicediscovery.InterfaceResolvedService;
 import com.google.common.net.InetAddresses;
-
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.APP_IDENTIFIER;
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROUP_NAME;
-import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROUP_UID;
 
 /**
  * A class representing service information for network service discovery. Unlike the
@@ -49,7 +46,7 @@ import static io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser.GROU
  * {@link P2PResolvedService} that represent the same group. In this sense a {@link P2PResolvedService} is
  * assigned to a group. This assignment can be set by calling the
  */
-public final class P2PResolvedService implements ResolvedService {
+public final class P2PResolvedService implements InterfaceResolvedService {
 
     private final InetAddress mInetAddress ;
     private final int mPort;
@@ -67,24 +64,24 @@ public final class P2PResolvedService implements ResolvedService {
 
         /*
 
-    public final static String PORT_LABEL = "port";
-    public final static String MONIKER_LABEL = "moniker";
-    public final static String DNS_VERSION_LABEL = "textvers";
+    public final static String DNS_TXT_PORT_LABEL = "port";
+    public final static String DNS_TXT_MONIKER_LABEL = "moniker";
+    public final static String DNS_TXT_DNS_VERSION_LABEL = "textvers";
     private final static String DNS_VERSION = "0.0.1";
-    public final static String BABBLE_VERSION_LABEL = "babblevers";
+    public final static String DNS_TXT_BABBLE_VERSION_LABEL = "babblevers";
 
-    public final static String GROUP_LABEL = "group";
+    public final static String DNS_TXT_GROUP_LABEL = "group";
 
          */
 
-   //     mInetAddress =  InetAddresses.forString((String) map.get(P2PService.HOST_LABEL));
-        mInetAddress =  InetAddresses.forString((String) map.get(P2PService.HOST_LABEL));
-        mPort = Integer.parseInt((String) map.get(P2PService.PORT_LABEL));
+   //     mInetAddress =  InetAddresses.forString((String) map.get(P2PService.DNS_TXT_HOST_LABEL));
+        mInetAddress =  InetAddresses.forString((String) map.get(BabbleConstants.DNS_TXT_HOST_LABEL));
+        mPort = Integer.parseInt((String) map.get(BabbleConstants.DNS_TXT_PORT_LABEL));
 
         mServiceAttributes = new HashMap<>(); //nsdServiceInfo.getAttributes();
 
-        mAppIdentifier = (String) map.get(P2PService.APP_LABEL);
-        mGroupName = (String) map.get(P2PService.GROUP_LABEL);
+        mAppIdentifier = (String) map.get(BabbleConstants.DNS_TXT_APP_LABEL);
+        mGroupName = (String) map.get(BabbleConstants.DNS_TXT_GROUP_LABEL);
         mGroupUid = uuID;
     }
 
@@ -92,7 +89,7 @@ public final class P2PResolvedService implements ResolvedService {
      * Get the group to which this instance has been assigned
      * @return the reoslved group
      */
-    public ResolvedGroup getResolvedGroup() {
+    public InterfaceResolvedGroup getResolvedGroup() {
         return mResolvedGroup;
     }
 
@@ -101,7 +98,7 @@ public final class P2PResolvedService implements ResolvedService {
      * in an {@link IllegalStateException}.
      * @param resolvedGroup the group to which the service should be assigned
      */
-    public void setResolvedGroup(ResolvedGroup resolvedGroup) {
+    public void setResolvedGroup(InterfaceResolvedGroup resolvedGroup) {
 
         if (mAssignedGroup) {
             throw new IllegalStateException("This service has already been assigned to a group");

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PServicesListAdapter.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PServicesListAdapter.java
@@ -36,6 +36,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.List;
 
 import io.mosaicnetworks.babble.R;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 
 public class P2PServicesListAdapter extends RecyclerView.Adapter<P2PServicesListAdapter.ViewHolder> {
 
@@ -55,11 +56,11 @@ public class P2PServicesListAdapter extends RecyclerView.Adapter<P2PServicesList
         }
     }
 
-    private List<P2PResolvedGroup> mData;
+    private List<ResolvedGroup> mData;
     private LayoutInflater mInflater;
     private ItemClickListener mClickListener;
 
-    public P2PServicesListAdapter(Context context, List<P2PResolvedGroup> data) {
+    public P2PServicesListAdapter(Context context, List<ResolvedGroup> data) {
         this.mInflater = LayoutInflater.from(context);
         this.mData = data;
     }
@@ -90,7 +91,7 @@ public class P2PServicesListAdapter extends RecyclerView.Adapter<P2PServicesList
     }
 
     // convenience method for getting data at click position
-    public P2PResolvedGroup getItem(int id) {
+    public ResolvedGroup getItem(int id) {
         return mData.get(id);
     }
 

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PServicesListView.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/P2PServicesListView.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import io.mosaicnetworks.babble.servicediscovery.ResolvedGroup;
 import io.mosaicnetworks.babble.servicediscovery.ServiceDiscoveryListener;
 import io.mosaicnetworks.babble.servicediscovery.ServicesListListener;
 
@@ -45,7 +46,7 @@ public class P2PServicesListView extends RecyclerView {
 
 
 
-    private List<P2PResolvedGroup> mServiceInfoList = new ArrayList<>();
+    private List<ResolvedGroup> mServiceInfoList = new ArrayList<>();
     private ServicesListListener mServicesListListener;
     private P2PService mP2PService;
     private boolean mPrevIsEmpty = true;

--- a/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/ResolvedServiceP2PFactory.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/servicediscovery/p2p/ResolvedServiceP2PFactory.java
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.mosaicnetworks.babble.servicediscovery.p2p;/*
+ * MIT License
+ *
+ * Copyright (c) 2018- Mosaic Networks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import com.google.common.net.InetAddresses;
+
+import java.util.Map;
+
+import io.mosaicnetworks.babble.discovery.PeersFactory;
+import io.mosaicnetworks.babble.node.BabbleConstants;
+import io.mosaicnetworks.babble.servicediscovery.ResolvedService;
+
+public abstract class ResolvedServiceP2PFactory {
+
+    public static ResolvedService NewJoinResolvedService(String dataProviderId,  Map<String, String> map) {
+
+        return new ResolvedService(
+                dataProviderId,
+                InetAddresses.forString((String) map.get(BabbleConstants.DNS_TXT_HOST_LABEL)),
+                "",
+                BabbleConstants.BABBLE_PORT(),
+                Integer.parseInt((String) map.get(BabbleConstants.DNS_TXT_PORT_LABEL)),
+                map,
+                (String) map.get(BabbleConstants.DNS_TXT_APP_LABEL),
+                (String) map.get(BabbleConstants.DNS_TXT_GROUP_LABEL),
+                (String) map.get(BabbleConstants.DNS_TXT_GROUP_ID_LABEL),
+                PeersFactory.toPeersList((String) map.get(BabbleConstants.DNS_TXT_INITIAL_PEERS_LABEL)),
+                PeersFactory.toPeersList((String) map.get(BabbleConstants.DNS_TXT_CURRENT_PEERS_LABEL))
+        );   //TODO: JK20Mar review this
+    }
+
+}

--- a/babble/src/main/res/values/babble.xml
+++ b/babble/src/main/res/values/babble.xml
@@ -29,6 +29,7 @@
 -->
 <resources>
     <integer name="babble_port">6666</integer>
+    <integer name="babble_discovery_port">8988</integer>
     <string name="babble_app_id"></string>
     <string name="babble_root_dir">babble</string>
     <string name="babble_db_subdir">badger_db</string>
@@ -36,4 +37,6 @@
     <string name="babble_peers_json">peers.json</string>
     <string name="babble_peers_genesis_json">peers.genesis.json</string>
     <string name="babble_priv_key">priv_key</string>
+    <string name="babble_service_type">_babble._tcp.</string>
+    <string name="babble_p2p_service_type">_presence._tcp</string>
 </resources>

--- a/sample/src/main/java/io/mosaicnetworks/sample/MessagingService.java
+++ b/sample/src/main/java/io/mosaicnetworks/sample/MessagingService.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 import io.mosaicnetworks.babble.discovery.HttpPeerDiscoveryServer;
 
+import io.mosaicnetworks.babble.discovery.PeersFactory;
+import io.mosaicnetworks.babble.node.BabbleConstants;
 import io.mosaicnetworks.babble.node.BabbleService;
 import io.mosaicnetworks.babble.servicediscovery.ServiceAdvertiser;
 import io.mosaicnetworks.babble.servicediscovery.mdns.MdnsAdvertiser;
@@ -48,7 +50,7 @@ import io.mosaicnetworks.babble.servicediscovery.p2p.P2PService;
 public final class MessagingService extends BabbleService<ChatState> {
 
     private static final String TAG = "MessagingService";
-    private static int sDiscoveryPort = 8988;
+    private static int sDiscoveryPort = BabbleConstants.DISCOVERY_PORT();
 
     private static MessagingService INSTANCE;
 //    private MdnsAdvertiser mMdnsAdvertiser;
@@ -86,14 +88,15 @@ public final class MessagingService extends BabbleService<ChatState> {
 
 
         switch (mNetworkType) {
-            case BabbleService.NETWORK_NONE:
+            case BabbleConstants.NETWORK_NONE:
                 Log.i(TAG, "NONE / Archive");
                 return;
-            case BabbleService.NETWORK_WIFI:
+            case BabbleConstants.NETWORK_WIFI:
                 Log.i(TAG, "WIFI / MDNS");
-                mAdvertiser = new MdnsAdvertiser(mGroupDescriptor, sDiscoveryPort, mAppContext);
+                mAdvertiser = new MdnsAdvertiser(mGroupDescriptor, sDiscoveryPort, mAppContext, mBabbleNode.getCurrentPeers(),
+                        mBabbleNode.getGenesisPeers() );
                 break;
-            case BabbleService.NETWORK_P2P:
+            case BabbleConstants.NETWORK_P2P:
                 Log.i(TAG, "P2P");
                 mAdvertiser = P2PService.getInstance(mAppContext);
                 break;


### PR DESCRIPTION
I am really mindful of how painful this could all be to pull back together. So I have created a develop-clone branch. This is just what it sounds. 

I want to piecemeal build the changes onto the develop-clone branch indigestible chunks. 

At the end of the process we will have an incompressible PR from develop-clone to develop, but if we have confidence in the interim steps we should be fine. 

Thus this is the first chunk. There are a lot of Constants changes the pull constants into BabbleConstants. There are 2 class of constants in there - ones that can be changed in babble.xml and ones that are fixed fixed - such as the names of DNS TXT fields.

This block also moves to a single ResolvedGroup and ResolvedService object. It is worth noting that serviceAttributes has been fixed as a Map<String, String>. It was Map<String, []byte> for mDNS (as provides by nsdInfo).

This is still a WIP, but it is probably as big a chunk as you want to review in one go.  

