### PR TITLE
Fix bug in archive display

### DIFF
--- a/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/configure/ArchivedGroupsFragment.java
@@ -255,6 +255,10 @@ public class ArchivedGroupsFragment extends BabbleServiceBinder implements Archi
         if (mActionMode!=null) {
             mActionMode.finish();
         }
+
+        if (mLoadingDialog!=null) {
+            mLoadingDialog.dismiss();
+        }
     }
 
     @Override

--- a/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleService2.java
+++ b/babble/src/main/java/io/mosaicnetworks/babble/service/BabbleService2.java
@@ -174,7 +174,9 @@ public class BabbleService2 extends Service {
             throw new IllegalStateException("Service is not running");
         }
 
-        mServiceAdvertiser.stopAdvertising();
+        if (mServiceAdvertiser!=null) {
+            mServiceAdvertiser.stopAdvertising();
+        }
 
         if (mBabbleNode==null) {
             //If an archive fails to load then the babble node can be null


### PR DESCRIPTION
Fix bug in BabbleService2 which caused a crash after displaying an
archive. Also hide loading dialog after returning from displaying an
archive.